### PR TITLE
Fix/libvirt

### DIFF
--- a/command-handler/src/commands/vm.js
+++ b/command-handler/src/commands/vm.js
@@ -52,64 +52,97 @@ export default {
         }
       } else if (actionId === 'button_create_vm') {
           const buttonsArray = [
-              { text: "aws", actionId: "button_create_vm_aws" },
-              { text: "hetzner", actionId: "button_create_vm_hetzner" },
-              { text: "libvirt", actionId: "button_create_vm_libvirt" },
+            { text: "aws", actionId: "button_create_vm_aws" },
+            { text: "hetzner", actionId: "button_create_vm_hetzner" },
+            { text: "libvirt", actionId: "button_create_vm_libvirt" },
           ];
           const buttons = buttonBuilder({ buttonsArray, headerText: "choose your platform", fallbackText: "device unsupported" });
           app.client.chat.postEphemeral({
-              channel: `${body.channel.id}`,
-              user: `${body.user.id}`,
-              text: 'select a platform',
-              ...buttons
+          channel: `${body.channel.id}`,
+          user: `${body.user.id}`,
+          text: 'select a platform',
+          ...buttons
           });
       } else if (actionId === 'button_start_aws') {
-          aws.startServer({ app, body, instanceId: data.instanceId, region: data.region });
+          const { instanceId, region } = JSON.parse(body.actions[0].value);
+            
+          aws.startServer({ app, body, instanceId, region });
       } else if (actionId === 'button_stop_aws') {
-          aws.stopServer({ app, body, instanceId: data.instanceId, region: data.region });
+          const { instanceId, region } = JSON.parse(body.actions[0].value);
+
+          aws.stopServer({ app, body, instanceId, region });
       } else if (actionId === 'button_delete_aws') {
-          aws.deleteServer({ app, body, instanceId: data.instanceId, serverName: data.serverName, region: data.region });
-      } else if (actionId === 'button_start_hetzner') {
-          hetzner.startServer({ app, body, vmID: data.vmID });
-      } else if (actionId === 'button_stop_hetzner') {
-          hetzner.stopServer({ app, body, vmID: data.vmID });
-      } else if (actionId === 'button_delete_hetzner') {
-          hetzner.deleteServer({ app, body, serverName: data.serverName });
-      } else if (actionId === 'button_start_libvirt') {
-          libvirt.startServer({ app, body, serverName: data.serverName, region: data.region });
-      } else if (actionId === 'button_stop_libvirt') {
-          libvirt.stopServer({ app, body, serverName: data.serverName, region: data.region });
-      } else if (actionId === 'button_delete_libvirt') {
-          libvirt.deleteServer({ app, body, serverName: data.serverName, region: data.region });
-      } else if (actionId.startsWith('button_create_image_aws')) {
-          aws.createServer({ app, body, imageName: data.imageName, ami: data.ami, region: data.region, instanceType: data.instanceType });
-      } else if (actionId.startsWith('button_create_image_hetzner')) {
-          hetzner.createServer({ app, body, imageID: data.imageID, imageName: data.imageName, region: data.region, serverType: data.serverType });
-      } else if (actionId.startsWith('button_create_image_libvirt')) {
-          libvirt.createServer({ app, body, imageName: data.imageName, region: data.region, instanceType: data.instanceType });
-      } else if (actionId === 'button_create_vm_hetzner') {
+          const { instanceId, serverName, region } = JSON.parse(body.actions[0].value);
+
+          //delete the server
+          aws.deleteServer({ app, body, instanceId, serverName, region });
+        } else if (actionId === 'button_start_hetzner') {
+          const { vmID } = JSON.parse(body.actions[0].value);
+          
+          //start a hetzner server
+          hetzner.startServer({ app, body, vmID });
+        } else if (actionId === 'button_stop_hetzner') {
+          const { vmID } = JSON.parse(body.actions[0].value);
+
+          //stop a hetzner server
+          hetzner.stopServer({ app, body, vmID });
+        } else if (actionId === 'button_delete_hetzner') {
+          const { serverName } = JSON.parse(body.actions[0].value);
+
+          //delete the server
+          hetzner.deleteServer({ app, body, serverName });
+        } else if (actionId === 'button_start_libvirt') {
+          const { serverName, region } = JSON.parse(body.actions[0].value);
+            
+          libvirt.startServer({ app, body, serverName, region });
+        } else if (actionId === 'button_stop_libvirt') {
+          const { serverName, region } = JSON.parse(body.actions[0].value);
+
+          libvirt.stopServer({ app, body, serverName, region });
+        } else if (actionId === 'button_delete_libvirt') {
+          const { serverName, region } = JSON.parse(body.actions[0].value);
+
+          //delete the server
+          libvirt.deleteServer({ app, body, serverName, region });
+        } else if (actionId.startsWith('button_create_image_aws')) {
+          const { imageName, ami, region, instanceType } = JSON.parse(body.actions[0].value);
+          aws.createServer({ app, body, imageName, ami, region, instanceType });
+        } else if (actionId.startsWith('button_create_image_hetzner')) {
+          const { imageID, imageName, region, serverType } = JSON.parse(body.actions[0].value);
+          hetzner.createServer({ app, body, imageID, imageName, region, serverType });
+        } else if (actionId.startsWith('button_create_image_libvirt')) {
+          const { imageName } = JSON.parse(body.actions[0].value);
+          libvirt.createServer({ app, body, imageName });
+        } else if (actionId === 'button_create_vm_hetzner') {
+          //select the hetzner server to create before calling the create server
           hetzner.selectRegion({ app, body });
-      } else if (actionId === 'button_create_vm_aws') {
+        } else if (actionId === 'button_create_vm_aws') {
+          //select the aws server to create before calling the create server
           aws.selectRegion({ app, body });
-      } else if (actionId === 'button_create_vm_libvirt') {
-          libvirt.selectRegion({ app, body });
-      } else if (actionId.startsWith('button_select_hetzner_server')) {
+        } else if (actionId === 'button_create_vm_libvirt') {
+          //select the libvirt image to create before calling the create server
+          libvirt.selectImage({ app, body });
+        } else if (actionId.startsWith('button_select_hetzner_server')) {
+          const data = JSON.parse(body.actions[0].value);
+          //select the hetzner server to create before calling the create server
           hetzner.selectServer({ app, body, data });
-      } else if (actionId.startsWith('button_select_libvirt_server')) {
-        libvirt.selectServer({ app, body, data });
-      } else if (actionId.startsWith('button_select_aws_server')) {
+        } else if (actionId.startsWith('button_select_aws_server')) {
+          const data = JSON.parse(body.actions[0].value);
+          //select the asw server to create before calling the create server
           aws.selectServer({ app, body, data });
-      } else if (actionId.startsWith('button_select_hetzner_image')) {
+        } else if (actionId.startsWith('button_select_hetzner_image')) {
+          const data = JSON.parse(body.actions[0].value);
+          //select the hetzner server to create before calling the create server
           hetzner.selectImage({ app, body, data });
-      } else if (actionId.startsWith('button_select_libvirt_image')) {
-          libvirt.selectImage({ app, body, data });
-      } else if (actionId.startsWith('button_select_aws_image')) {
+        } else if (actionId.startsWith('button_select_aws_image')) {
+          const data = JSON.parse(body.actions[0].value);
+          //select the asw server to create before calling the create server
           aws.selectImage({ app, body, data });
-      } else {
+        } else {
           response({
-              text: `This button is registered with the vm command, but does not have an action associated with it.`
+            text: `This button is registered with the vm command, but does not have an action associated with it.`
           });
-      }
+        }
     },
     
     run: async ({ event, app }) => {

--- a/command-handler/src/commands/vm.js
+++ b/command-handler/src/commands/vm.js
@@ -111,8 +111,8 @@ export default {
           const { imageID, imageName, region, serverType } = JSON.parse(body.actions[0].value);
           hetzner.createServer({ app, body, imageID, imageName, region, serverType });
         } else if (actionId.startsWith('button_create_image_libvirt')) {
-          const { imageName } = JSON.parse(body.actions[0].value);
-          libvirt.createServer({ app, body, imageName });
+          const { imageName, instanceType } = JSON.parse(body.actions[0].value);
+          libvirt.createServer({ app, body, imageName, instanceType });
         } else if (actionId === 'button_create_vm_hetzner') {
           //select the hetzner server to create before calling the create server
           hetzner.selectRegion({ app, body });
@@ -121,7 +121,7 @@ export default {
           aws.selectRegion({ app, body });
         } else if (actionId === 'button_create_vm_libvirt') {
           //select the libvirt image to create before calling the create server
-          libvirt.selectImage({ app, body });
+          libvirt.selectRegion({ app, body });
         } else if (actionId.startsWith('button_select_hetzner_server')) {
           const data = JSON.parse(body.actions[0].value);
           //select the hetzner server to create before calling the create server
@@ -130,6 +130,10 @@ export default {
           const data = JSON.parse(body.actions[0].value);
           //select the asw server to create before calling the create server
           aws.selectServer({ app, body, data });
+        } else if (actionId.startsWith('button_select_libvirt_server')) {
+          const data = JSON.parse(body.actions[0].value);
+          //select the libvirt server type to create before calling the create server
+          libvirt.selectServer({ app, body, data });
         } else if (actionId.startsWith('button_select_hetzner_image')) {
           const data = JSON.parse(body.actions[0].value);
           //select the hetzner server to create before calling the create server
@@ -138,6 +142,10 @@ export default {
           const data = JSON.parse(body.actions[0].value);
           //select the asw server to create before calling the create server
           aws.selectImage({ app, body, data });
+        } else if (actionId.startsWith('button_select_libvirt_image')) {
+          const data = JSON.parse(body.actions[0].value);
+          //select the hetzner server to create before calling the create server
+          libvirt.selectImage({ app, body, data });
         } else {
           response({
             text: `This button is registered with the vm command, but does not have an action associated with it.`

--- a/command-handler/src/commands/vm.js
+++ b/command-handler/src/commands/vm.js
@@ -52,97 +52,64 @@ export default {
         }
       } else if (actionId === 'button_create_vm') {
           const buttonsArray = [
-            { text: "aws", actionId: "button_create_vm_aws" },
-            { text: "hetzner", actionId: "button_create_vm_hetzner" },
-            { text: "libvirt", actionId: "button_create_vm_libvirt" },
+              { text: "aws", actionId: "button_create_vm_aws" },
+              { text: "hetzner", actionId: "button_create_vm_hetzner" },
+              { text: "libvirt", actionId: "button_create_vm_libvirt" },
           ];
           const buttons = buttonBuilder({ buttonsArray, headerText: "choose your platform", fallbackText: "device unsupported" });
           app.client.chat.postEphemeral({
-          channel: `${body.channel.id}`,
-          user: `${body.user.id}`,
-          text: 'select a platform',
-          ...buttons
+              channel: `${body.channel.id}`,
+              user: `${body.user.id}`,
+              text: 'select a platform',
+              ...buttons
           });
       } else if (actionId === 'button_start_aws') {
-          const { instanceId, region } = JSON.parse(body.actions[0].value);
-            
-          aws.startServer({ app, body, instanceId, region });
+          aws.startServer({ app, body, instanceId: data.instanceId, region: data.region });
       } else if (actionId === 'button_stop_aws') {
-          const { instanceId, region } = JSON.parse(body.actions[0].value);
-
-          aws.stopServer({ app, body, instanceId, region });
+          aws.stopServer({ app, body, instanceId: data.instanceId, region: data.region });
       } else if (actionId === 'button_delete_aws') {
-          const { instanceId, serverName, region } = JSON.parse(body.actions[0].value);
-
-          //delete the server
-          aws.deleteServer({ app, body, instanceId, serverName, region });
-        } else if (actionId === 'button_start_hetzner') {
-          const { vmID } = JSON.parse(body.actions[0].value);
-          
-          //start a hetzner server
-          hetzner.startServer({ app, body, vmID });
-        } else if (actionId === 'button_stop_hetzner') {
-          const { vmID } = JSON.parse(body.actions[0].value);
-
-          //stop a hetzner server
-          hetzner.stopServer({ app, body, vmID });
-        } else if (actionId === 'button_delete_hetzner') {
-          const { serverName } = JSON.parse(body.actions[0].value);
-
-          //delete the server
-          hetzner.deleteServer({ app, body, serverName });
-        } else if (actionId === 'button_start_libvirt') {
-          const { serverName } = JSON.parse(body.actions[0].value);
-            
-          libvirt.startServer({ app, body, serverName });
-        } else if (actionId === 'button_stop_libvirt') {
-          const { serverName } = JSON.parse(body.actions[0].value);
-
-          libvirt.stopServer({ app, body, serverName });
-        } else if (actionId === 'button_delete_libvirt') {
-          const { serverName } = JSON.parse(body.actions[0].value);
-
-          //delete the server
-          libvirt.deleteServer({ app, body, serverName });
-        } else if (actionId.startsWith('button_create_image_aws')) {
-          const { imageName, ami, region, instanceType } = JSON.parse(body.actions[0].value);
-          aws.createServer({ app, body, imageName, ami, region, instanceType });
-        } else if (actionId.startsWith('button_create_image_hetzner')) {
-          const { imageID, imageName, region, serverType } = JSON.parse(body.actions[0].value);
-          hetzner.createServer({ app, body, imageID, imageName, region, serverType });
-        } else if (actionId.startsWith('button_create_image_libvirt')) {
-          const { imageName } = JSON.parse(body.actions[0].value);
-          libvirt.createServer({ app, body, imageName });
-        } else if (actionId === 'button_create_vm_hetzner') {
-          //select the hetzner server to create before calling the create server
+          aws.deleteServer({ app, body, instanceId: data.instanceId, serverName: data.serverName, region: data.region });
+      } else if (actionId === 'button_start_hetzner') {
+          hetzner.startServer({ app, body, vmID: data.vmID });
+      } else if (actionId === 'button_stop_hetzner') {
+          hetzner.stopServer({ app, body, vmID: data.vmID });
+      } else if (actionId === 'button_delete_hetzner') {
+          hetzner.deleteServer({ app, body, serverName: data.serverName });
+      } else if (actionId === 'button_start_libvirt') {
+          libvirt.startServer({ app, body, serverName: data.serverName, region: data.region });
+      } else if (actionId === 'button_stop_libvirt') {
+          libvirt.stopServer({ app, body, serverName: data.serverName, region: data.region });
+      } else if (actionId === 'button_delete_libvirt') {
+          libvirt.deleteServer({ app, body, serverName: data.serverName, region: data.region });
+      } else if (actionId.startsWith('button_create_image_aws')) {
+          aws.createServer({ app, body, imageName: data.imageName, ami: data.ami, region: data.region, instanceType: data.instanceType });
+      } else if (actionId.startsWith('button_create_image_hetzner')) {
+          hetzner.createServer({ app, body, imageID: data.imageID, imageName: data.imageName, region: data.region, serverType: data.serverType });
+      } else if (actionId.startsWith('button_create_image_libvirt')) {
+          libvirt.createServer({ app, body, imageName: data.imageName, region: data.region, instanceType: data.instanceType });
+      } else if (actionId === 'button_create_vm_hetzner') {
           hetzner.selectRegion({ app, body });
-        } else if (actionId === 'button_create_vm_aws') {
-          //select the aws server to create before calling the create server
+      } else if (actionId === 'button_create_vm_aws') {
           aws.selectRegion({ app, body });
-        } else if (actionId === 'button_create_vm_libvirt') {
-          //select the libvirt image to create before calling the create server
-          libvirt.selectImage({ app, body });
-        } else if (actionId.startsWith('button_select_hetzner_server')) {
-          const data = JSON.parse(body.actions[0].value);
-          //select the hetzner server to create before calling the create server
+      } else if (actionId === 'button_create_vm_libvirt') {
+          libvirt.selectRegion({ app, body });
+      } else if (actionId.startsWith('button_select_hetzner_server')) {
           hetzner.selectServer({ app, body, data });
-        } else if (actionId.startsWith('button_select_aws_server')) {
-          const data = JSON.parse(body.actions[0].value);
-          //select the asw server to create before calling the create server
+      } else if (actionId.startsWith('button_select_libvirt_server')) {
+        libvirt.selectServer({ app, body, data });
+      } else if (actionId.startsWith('button_select_aws_server')) {
           aws.selectServer({ app, body, data });
-        } else if (actionId.startsWith('button_select_hetzner_image')) {
-          const data = JSON.parse(body.actions[0].value);
-          //select the hetzner server to create before calling the create server
+      } else if (actionId.startsWith('button_select_hetzner_image')) {
           hetzner.selectImage({ app, body, data });
-        } else if (actionId.startsWith('button_select_aws_image')) {
-          const data = JSON.parse(body.actions[0].value);
-          //select the asw server to create before calling the create server
+      } else if (actionId.startsWith('button_select_libvirt_image')) {
+          libvirt.selectImage({ app, body, data });
+      } else if (actionId.startsWith('button_select_aws_image')) {
           aws.selectImage({ app, body, data });
-        } else {
+      } else {
           response({
-            text: `This button is registered with the vm command, but does not have an action associated with it.`
+              text: `This button is registered with the vm command, but does not have an action associated with it.`
           });
-        }
+      }
     },
     
     run: async ({ event, app }) => {

--- a/command-handler/src/commands/vm.js
+++ b/command-handler/src/commands/vm.js
@@ -112,7 +112,7 @@ export default {
           hetzner.createServer({ app, body, imageID, imageName, region, serverType });
         } else if (actionId.startsWith('button_create_image_libvirt')) {
           const { imageName, instanceType } = JSON.parse(body.actions[0].value);
-          libvirt.createServer({ app, body, imageName, instanceType });
+          libvirt.createServer({ app, body, imageName, region, instanceType });
         } else if (actionId === 'button_create_vm_hetzner') {
           //select the hetzner server to create before calling the create server
           hetzner.selectRegion({ app, body });

--- a/command-handler/src/commands/vm.js
+++ b/command-handler/src/commands/vm.js
@@ -111,7 +111,7 @@ export default {
           const { imageID, imageName, region, serverType } = JSON.parse(body.actions[0].value);
           hetzner.createServer({ app, body, imageID, imageName, region, serverType });
         } else if (actionId.startsWith('button_create_image_libvirt')) {
-          const { imageName, instanceType } = JSON.parse(body.actions[0].value);
+          const { imageName, region, instanceType } = JSON.parse(body.actions[0].value);
           libvirt.createServer({ app, body, imageName, region, instanceType });
         } else if (actionId === 'button_create_vm_hetzner') {
           //select the hetzner server to create before calling the create server

--- a/command-handler/src/util/libvirt/libvirt-server.js
+++ b/command-handler/src/util/libvirt/libvirt-server.js
@@ -351,7 +351,7 @@ export default {
 
         //build button for user to select
         for (const image of images) {
-            data.image = image;
+            data.imageName = image;
             buttonsArray.push({ text: image, actionId: `button_create_image_libvirt_${image}`, value: JSON.stringify(data) })
         }
 

--- a/command-handler/src/util/libvirt/libvirt-server.js
+++ b/command-handler/src/util/libvirt/libvirt-server.js
@@ -365,9 +365,8 @@ export default {
     selectServer: async ({app, body, data }) => {
         const buttonsArray = [];
 
-        console.log(data);
         for (const serverType of data.instances) {
-        buttonsArray.push({ text: serverType, actionId: `button_select_libvirt_image_${serverType}`, value: JSON.stringify(data) });
+        buttonsArray.push({ text: serverType.instance_type, actionId: `button_select_libvirt_image_${serverType.instance_type}`, value: JSON.stringify(data) });
         };
         const buttons = buttonBuilder({ buttonsArray, headerText: 'Select a server', fallbackText: 'unsupported device' });
         app.client.chat.postEphemeral({

--- a/command-handler/src/util/libvirt/libvirt-server.js
+++ b/command-handler/src/util/libvirt/libvirt-server.js
@@ -285,7 +285,7 @@ export default {
     selectRegion: async ({app, body }) => {
         const buttonsArray = [];
         //get the regions from the env variable
-        const regions = await axios.get(`${process.env.PROVISIONER_URL}/v1/regions`, {
+        const response = await axios.get(`${process.env.PROVISIONER_URL}/v1/regions`, {
             headers: {
               'Authorization': `${process.env.PROVISIONER_API_TOKEN}`
             },
@@ -294,6 +294,8 @@ export default {
           .catch(error => {
             log.error('Failed to get regions from libvirt', axiosError(error));
         });
+
+        const regions = response?.data;
         
         //return if it fails to get a response from libvirt.
         if (!regions) {

--- a/command-handler/src/util/libvirt/libvirt-server.js
+++ b/command-handler/src/util/libvirt/libvirt-server.js
@@ -16,7 +16,7 @@ const delay = (ms) => {
 }
 
 export default {
-    createServer: async({ app, body, imageName }) => {
+    createServer: async({ app, body, imageName, region, instanceType }) => {
         //auto generate the name
         const serverName = uniqueNamesGenerator({ 
             dictionaries: [ colors, animals ],
@@ -59,7 +59,9 @@ export default {
                         "owner": userEmail,
                     },
                     "user_data": Buffer.from(configUserData(serverName)).toString('base64'),
-                    "image": imageName
+                    "image": imageName,
+                    "region_name": region,
+                    "instance_type": instanceType
                 }, {
                 headers: {
                     'Authorization': `${process.env.PROVISIONER_API_TOKEN}`,
@@ -366,7 +368,7 @@ export default {
         const buttonsArray = [];
 
         for (const serverType of data.instances) {
-            data.serverType = serverType.instance_type;
+            data.instanceType = serverType.instance_type;
             buttonsArray.push({ text: serverType.instance_type, actionId: `button_select_libvirt_image_${serverType.instance_type}`, value: JSON.stringify(data) });
         };
         const buttons = buttonBuilder({ buttonsArray, headerText: 'Select a server', fallbackText: 'unsupported device' });

--- a/command-handler/src/util/libvirt/libvirt-server.js
+++ b/command-handler/src/util/libvirt/libvirt-server.js
@@ -209,7 +209,7 @@ export default {
     
         for (const server of data) {
         
-            const owner = server.description.owner;
+            const owner = server.tags.owner;
 
             const { deviceIP } = await getDevices(server.name);
             

--- a/command-handler/src/util/libvirt/libvirt-server.js
+++ b/command-handler/src/util/libvirt/libvirt-server.js
@@ -366,7 +366,8 @@ export default {
         const buttonsArray = [];
 
         for (const serverType of data.instances) {
-        buttonsArray.push({ text: serverType.instance_type, actionId: `button_select_libvirt_image_${serverType.instance_type}`, value: JSON.stringify(data) });
+            data.serverType = serverType.instance_type;
+            buttonsArray.push({ text: serverType.instance_type, actionId: `button_select_libvirt_image_${serverType.instance_type}`, value: JSON.stringify(data) });
         };
         const buttons = buttonBuilder({ buttonsArray, headerText: 'Select a server', fallbackText: 'unsupported device' });
         app.client.chat.postEphemeral({

--- a/command-handler/src/util/libvirt/libvirt-server.js
+++ b/command-handler/src/util/libvirt/libvirt-server.js
@@ -308,7 +308,7 @@ export default {
 
         //build button for user to select
         for (const region of regions) {
-        buttonsArray.push({ text: region.region_name, actionId: `button_select_libvirt_image_${region.region_name}`, value: JSON.stringify({ region: region.region_name, instances: region.available_instance_types }) });
+        buttonsArray.push({ text: region.region_name, actionId: `button_select_libvirt_server${region.region_name}`, value: JSON.stringify({ region: region.region_name, instances: region.available_instance_types }) });
         }
         const buttons = buttonBuilder({ buttonsArray, headerText: 'Select a region', fallbackText: 'unsupported device' });
         app.client.chat.postEphemeral({
@@ -362,11 +362,9 @@ export default {
 
     selectServer: async ({app, body, data }) => {
         const buttonsArray = [];
-        const serverTypes = process.env.HETZNER_SERVER_TYPES.split(',').map(server => server.trim()).filter(server => server);
 
-        for (const serverType of serverTypes) {
-        data.serverType = serverType;
-        buttonsArray.push({ text: serverType, actionId: `button_select_hetzner_image_${serverType}`, value: JSON.stringify(data) });
+        for (const serverType of data.instances) {
+        buttonsArray.push({ text: serverType, actionId: `button_select_libvirt_image_${serverType}`, value: JSON.stringify(data) });
         };
         const buttons = buttonBuilder({ buttonsArray, headerText: 'Select a server', fallbackText: 'unsupported device' });
         app.client.chat.postEphemeral({

--- a/command-handler/src/util/libvirt/libvirt-server.js
+++ b/command-handler/src/util/libvirt/libvirt-server.js
@@ -81,16 +81,6 @@ export default {
             return;
         }
         
-        if (serverRes.data !== 'Success') {
-            app.client.chat.postEphemeral({
-            channel: `${body.channel.id}`,
-            user: `${body.user.id}`,
-            text: `Failed to create a server.`
-            });
-
-            return;
-        }
-        
         let attempts;
 
         let maxRetries = 13;  

--- a/command-handler/src/util/libvirt/libvirt-server.js
+++ b/command-handler/src/util/libvirt/libvirt-server.js
@@ -365,6 +365,7 @@ export default {
     selectServer: async ({app, body, data }) => {
         const buttonsArray = [];
 
+        console.log(data);
         for (const serverType of data.instances) {
         buttonsArray.push({ text: serverType, actionId: `button_select_libvirt_image_${serverType}`, value: JSON.stringify(data) });
         };

--- a/command-handler/src/util/libvirt/libvirt-server.js
+++ b/command-handler/src/util/libvirt/libvirt-server.js
@@ -56,9 +56,7 @@ export default {
                 {
                     "vm_name": serverName,
                     "tags": {
-                        "owner": {
-                        "name": userEmail
-                        }
+                        "owner": userEmail,
                     },
                     "user_data": Buffer.from(configUserData(serverName)).toString('base64'),
                     "image": imageName
@@ -67,7 +65,7 @@ export default {
                     'Authorization': `${process.env.PROVISIONER_API_TOKEN}`,
                     'Content-Type': 'application/json'
                 },
-                timeout: 1000 * 60 * 2
+                timeout: 1000 * 60 * 5
             });
         } catch (error) {
             log.error('There was an error creating the server', axiosError(error));
@@ -133,7 +131,7 @@ export default {
         });
     },
 
-    deleteServer: async ({ app, body, serverName }) => {
+    deleteServer: async ({ app, body, serverName, region }) => {
         //get servers from tailscale
         const { deviceId } = await getDevices(serverName)
 
@@ -151,7 +149,10 @@ export default {
 
         try {
             await axios.delete(`${process.env.PROVISIONER_URL}/v1/delete`, {
-                data: { "vm_name": serverName },
+                data: { 
+                    "vm_name": serverName,
+                    "region_name": region 
+                },
                 headers: {
                     'Authorization': `${process.env.PROVISIONER_API_TOKEN}`
                 }
@@ -194,7 +195,7 @@ export default {
             log.error('Failed to get servers from libvirt', axiosError(error));
         });
 
-        const data = response.data;
+        const data = response?.data;
 
         if (!data) {
             app.client.chat.postEphemeral({
@@ -208,7 +209,7 @@ export default {
     
         for (const server of data) {
         
-            const owner = server.description.owner.name;
+            const owner = server.description.owner;
 
             const { deviceIP } = await getDevices(server.name);
             
@@ -217,6 +218,7 @@ export default {
             servers.push({
                 cloud: "libvirt",
                 serverName: `${server.name}`,
+                region: `${server.region_name}`,
                 status: `${server.state}`,
                 connect: `https://login.tailscale.com/admin/machines/${deviceIP}`
             });
@@ -226,10 +228,11 @@ export default {
         return servers;
     },
 
-    startServer: async({ app, body, serverName }) => {
+    startServer: async({ app, body, serverName, region }) => {
         try {
             await axios.post(`${process.env.PROVISIONER_URL}/v1/start`, {
-                "vm_name": serverName
+                "vm_name": serverName,
+                "region_name": region
             }, {
                 headers: {
                 'Authorization': `${process.env.PROVISIONER_API_TOKEN}`
@@ -252,10 +255,11 @@ export default {
         } 
     },
 
-    stopServer: async({ app, body, serverName }) => {
+    stopServer: async({ app, body, serverName, region }) => {
         try {
             await axios.post(`${process.env.PROVISIONER_URL}/v1/stop`, {
-                "vm_name": serverName
+                "vm_name": serverName,
+                "region_name": region
             }, {
                 headers: {
                 'Authorization': `${process.env.PROVISIONER_API_TOKEN}`
@@ -278,7 +282,44 @@ export default {
         } 
     },
 
-    selectImage: async({ app, body }) => {
+    selectRegion: async ({app, body }) => {
+        const buttonsArray = [];
+        //get the regions from the env variable
+        const regions = await axios.get(`${process.env.PROVISIONER_URL}/v1/regions`, {
+            headers: {
+              'Authorization': `${process.env.PROVISIONER_API_TOKEN}`
+            },
+            timeout: 1000 * 60 * 5
+          })
+          .catch(error => {
+            log.error('Failed to get regions from libvirt', axiosError(error));
+        });
+        
+        //return if it fails to get a response from libvirt.
+        if (!regions) {
+        app.client.chat.postEphemeral({
+            channel: `${body.channel.id}`,
+            user: `${body.user.id}`,
+            text: `Failed to get region data from libvirt`
+        });
+
+        return;
+        }
+
+        //build button for user to select
+        for (const region of regions) {
+        buttonsArray.push({ text: region.region_name, actionId: `button_select_libvirt_image_${region.region_name}`, value: JSON.stringify({ region: region.region_name, instances: region.available_instance_types }) });
+        }
+        const buttons = buttonBuilder({ buttonsArray, headerText: 'Select a region', fallbackText: 'unsupported device' });
+        app.client.chat.postEphemeral({
+        channel: `${body.channel.id}`,
+        user: `${body.user.id}`,
+        text: 'select a region',
+        ...buttons
+        });
+    },
+    
+    selectImage: async({ app, body, data }) => {
         //get the libvirt images
 
         // Fetch tags from the repository
@@ -306,7 +347,8 @@ export default {
 
         //build button for user to select
         for (const image of images) {
-            buttonsArray.push({ text: image, actionId: `button_create_image_libvirt_${image}`, value: JSON.stringify({ imageName: image }) })
+            data.image = image;
+            buttonsArray.push({ text: image, actionId: `button_create_image_libvirt_${image}`, value: JSON.stringify(data) })
         }
 
         const buttons = buttonBuilder({ buttonsArray, headerText: 'Select an image', fallbackText: 'unsupported device' });
@@ -317,4 +359,21 @@ export default {
             ...buttons
         });
     },
+
+    selectServer: async ({app, body, data }) => {
+        const buttonsArray = [];
+        const serverTypes = process.env.HETZNER_SERVER_TYPES.split(',').map(server => server.trim()).filter(server => server);
+
+        for (const serverType of serverTypes) {
+        data.serverType = serverType;
+        buttonsArray.push({ text: serverType, actionId: `button_select_hetzner_image_${serverType}`, value: JSON.stringify(data) });
+        };
+        const buttons = buttonBuilder({ buttonsArray, headerText: 'Select a server', fallbackText: 'unsupported device' });
+        app.client.chat.postEphemeral({
+        channel: `${body.channel.id}`,
+        user: `${body.user.id}`,
+        text: 'select a server',
+        ...buttons
+        });
+    }
 };


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added `region` and `instanceType` parameters to libvirt server operations.

- Enhanced server creation flow with region and instance type selection.

- Fixed issues with undefined values for `region` and `image`.

- Improved error handling and timeout configurations in libvirt operations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vm.js</strong><dd><code>Updated libvirt button actions and parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

command-handler/src/commands/vm.js

<li>Added <code>region</code> and <code>instanceType</code> parameters to libvirt operations.<br> <li> Updated button actions to include region and instance type handling.<br> <li> Introduced new button actions for selecting libvirt servers and <br>images.<br> <li> Replaced <code>selectImage</code> with <code>selectRegion</code> for libvirt VM creation.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/slackbot-developer-workspaces/pull/125/files#diff-8da8925f3c89d825e25c24402809b1cc0351261022da32bb5c68cd0b21ed2e47">+17/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>libvirt-server.js</strong><dd><code>Enhanced libvirt server operations and selection methods</code>&nbsp; </dd></summary>
<hr>

command-handler/src/util/libvirt/libvirt-server.js

<li>Added <code>region</code> and <code>instanceType</code> parameters to server operations.<br> <li> Enhanced server creation with region and instance type selection.<br> <li> Improved error handling for region and server data retrieval.<br> <li> Added new methods for selecting regions, servers, and images.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/slackbot-developer-workspaces/pull/125/files#diff-afc9a00c537e4414b9453631379a6fd06ee570184dfb71a84aa25bc23730c65d">+79/-27</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information