### PR TITLE
fix: add hostname to user-data

### DIFF
--- a/command-handler/src/util/get-user-data.js
+++ b/command-handler/src/util/get-user-data.js
@@ -6,6 +6,8 @@
 export default function configUserData(serverName) {
     const userData = `
         #cloud-config
+        hostname: ${serverName}
+        manage_etc_hosts: true
         runcmd:
             - ['tailscale', 'up', '--authkey=${process.env.TAILSCALE_AUTH_KEY}', '--hostname=${serverName}']
             - ['tailscale', 'set', '--ssh']


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added hostname configuration to user-data for VMs.

- Enabled management of `/etc/hosts` in user-data.

- Enhanced cloud-init script with hostname and hosts management.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>get-user-data.js</strong><dd><code>Add hostname and manage `/etc/hosts` in user-data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

command-handler/src/util/get-user-data.js

<li>Added <code>hostname</code> configuration to the user-data template.<br> <li> Enabled <code>manage_etc_hosts</code> in the cloud-init configuration.<br> <li> Updated <code>runcmd</code> to use the hostname dynamically.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/slackbot-developer-workspaces/pull/126/files#diff-b8cda29edc7398c1d4fd20be8aeff04af03c5952770381c398e0e9dc2e63027f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information