### PR TITLE
fix: add beta text to libvirt

### DIFF
--- a/command-handler/src/commands/vm.js
+++ b/command-handler/src/commands/vm.js
@@ -54,7 +54,7 @@ export default {
           const buttonsArray = [
             { text: "aws", actionId: "button_create_vm_aws" },
             { text: "hetzner", actionId: "button_create_vm_hetzner" },
-            { text: "libvirt", actionId: "button_create_vm_libvirt" },
+            { text: "libvirt (beta)", actionId: "button_create_vm_libvirt" },
           ];
           const buttons = buttonBuilder({ buttonsArray, headerText: "choose your platform", fallbackText: "device unsupported" });
           app.client.chat.postEphemeral({


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Updated the label for the 'libvirt' button to include '(beta)'.

- Improved clarity for the 'libvirt' platform option.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vm.js</strong><dd><code>Add beta label to 'libvirt' button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

command-handler/src/commands/vm.js

<li>Updated the text for the 'libvirt' button to 'libvirt (beta)'.<br> <li> Ensured the platform option reflects its beta status.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/slackbot-developer-workspaces/pull/127/files#diff-8da8925f3c89d825e25c24402809b1cc0351261022da32bb5c68cd0b21ed2e47">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information