### PR TITLE
fix: spelling in the server stopped status message

### DIFF
--- a/command-handler/src/util/libvirt/libvirt-server.js
+++ b/command-handler/src/util/libvirt/libvirt-server.js
@@ -261,7 +261,7 @@ export default {
             app.client.chat.postEphemeral({
               channel: `${body.channel.id}`,
               user: `${body.user.id}`,
-              text: `Server: ${serverName} has been Stoped.`
+              text: `Server: ${serverName} has been Stopped.`
             });
         } catch (error) {
             log.error('Failed to stop the server', axiosError(error));


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Corrected a spelling error in the server stopped status message.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>libvirt-server.js</strong><dd><code>Corrected typo in server stopped message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

command-handler/src/util/libvirt/libvirt-server.js

<li>Fixed a typo in the server stopped status message.<br> <li> Changed "Stoped" to "Stopped" in the text output.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/slackbot-developer-workspaces/pull/148/files#diff-afc9a00c537e4414b9453631379a6fd06ee570184dfb71a84aa25bc23730c65d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>