### PR TITLE
fix: change the image api to use provisioner

### DIFF
--- a/command-handler/src/util/libvirt/libvirt-server.js
+++ b/command-handler/src/util/libvirt/libvirt-server.js
@@ -315,13 +315,11 @@ export default {
     
     selectImage: async({ app, body, data }) => {
         //get the libvirt images
-
-        // Fetch tags from the repository
         let images = [];
-
+        // Fetch tags from the repository
         try {
-            const res = await axios.get('https://api.github.com/repos/GlueOps/codespaces/tags');
-            images = res.data.slice(0, 5).map(tag => tag.name);
+            const res = await axios.get(`${process.env.PROVISIONER_URL}/v1/get-images`);
+            images = res.data.images;
         } catch (error) {
             log.error('Error fetching tags:', axiosError(error));
         }
@@ -341,7 +339,6 @@ export default {
 
         //build button for user to select
         for (const image of images) {
-            data.imageName = image;
             buttonsArray.push({ text: image, actionId: `button_create_image_libvirt_${image}`, value: JSON.stringify(data) })
         }
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated image API to use the provisioner service.

- Replaced GitHub tags fetching with provisioner API call.

- Improved error handling for image data retrieval.

- Simplified button creation logic for image selection.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>libvirt-server.js</strong><dd><code>Refactor image API to use provisioner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

command-handler/src/util/libvirt/libvirt-server.js

<li>Changed image API endpoint to use provisioner.<br> <li> Removed GitHub tags fetching logic.<br> <li> Adjusted error handling for API call failures.<br> <li> Simplified logic for building image selection buttons.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/slackbot-developer-workspaces/pull/180/files#diff-afc9a00c537e4414b9453631379a6fd06ee570184dfb71a84aa25bc23730c65d">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>