### PR TITLE
fix: accept a scheme-less PROFILES_S3_ENDPOINT and validate it at startup

### DIFF
--- a/example.env
+++ b/example.env
@@ -9,7 +9,8 @@ GUACAMOLE_CONNECTION_URL=<URL for guacamole connections>
 APP_ENVIRONMENT=<nonprod | prod>
 
 # VM profiles store (required). The app fails to start if any of these are missing.
-PROFILES_S3_ENDPOINT=<S3 endpoint URL, e.g. https://s3.us-east-1.amazonaws.com>
+# Must be a full URL including the scheme (https://). A bare host is rejected at startup.
+PROFILES_S3_ENDPOINT=https://s3.us-east-1.amazonaws.com
 PROFILES_S3_BUCKET=<bucket name>
 PROFILES_S3_REGION=<bucket region, e.g. us-east-1>
 PROFILES_S3_ACCESS_KEY_ID=<access key id>

--- a/util/profile-store.js
+++ b/util/profile-store.js
@@ -27,9 +27,18 @@ import { encrypt, decrypt, encryptionKeyValid, hashEmail } from './profile-crypt
 
 const log = logger();
 
+// The AWS SDK needs an ABSOLUTE URL (with scheme) for a custom endpoint; a bare host like
+// "s3.example.com" throws a cryptic "Invalid URL" deep inside the SDK on first use. Default
+// to https:// when the scheme is omitted so the common misconfiguration just works.
+function normalizeEndpoint(ep) {
+    const v = (ep || '').trim();
+    if (!v) return undefined;
+    return /^https?:\/\//i.test(v) ? v : `https://${v}`;
+}
+
 const BUCKET = process.env.PROFILES_S3_BUCKET;
 const REGION = process.env.PROFILES_S3_REGION;
-const ENDPOINT = process.env.PROFILES_S3_ENDPOINT || undefined;
+const ENDPOINT = normalizeEndpoint(process.env.PROFILES_S3_ENDPOINT);
 const PREFIX = process.env.PROFILES_S3_PREFIX ?? 'profiles/';
 // Bound every S3 call so an unresponsive endpoint can't hang a Slack interaction forever
 // (the AWS SDK's default request timeout is 0 = unbounded). AbortSignal.timeout fires once
@@ -77,6 +86,13 @@ export function requireProfilesConfig() {
     }
     if (!encryptionKeyValid()) {
         throw new Error('PROFILES_ENCRYPTION_KEY must be 32 bytes as 64 hex chars (generate with: openssl rand -hex 32)');
+    }
+    // Catch a malformed endpoint at startup with a clear message, instead of a cryptic
+    // "Invalid URL" from the AWS SDK on the first profile read/write.
+    try {
+        new URL(ENDPOINT);
+    } catch {
+        throw new Error(`PROFILES_S3_ENDPOINT is not a valid URL: "${process.env.PROFILES_S3_ENDPOINT}" (expected e.g. https://s3.us-east-1.amazonaws.com)`);
     }
 }
 


### PR DESCRIPTION
## Problem

A `PROFILES_S3_ENDPOINT` set to a bare host (e.g. `s3.us-west-2.amazonaws.com`, no scheme) makes the AWS SDK throw `TypeError: Invalid URL` on the first profile read/write. Users see `Failed to save profile <name>. Please try again.`, and the logs show `ERR_INVALID_URL` from the SDK's endpoint parser. A leftover `example.env` placeholder (`<S3 endpoint URL ...>`) fails the same way.

## Fix

- **Normalize** a scheme-less endpoint to `https://` so the common misconfiguration just works.
- **Validate** the endpoint URL in `requireProfilesConfig()` so a truly malformed value fails fast at startup with a clear message, instead of a cryptic SDK error on first use.
- Update `example.env` to show a full `https://` URL and note the requirement.

## Verification

In `node:24-alpine`:
- scheme-less `s3.us-east-1.amazonaws.com` → accepted (normalized)
- placeholder `<S3 endpoint URL ...>` → rejected at startup with a clear message
- proper `https://s3.us-east-1.amazonaws.com` → accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)