### PR TITLE
feat: make VM profiles the only way to set env vars on create

### DIFF
--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -39,7 +39,7 @@ import redactSensitive from './util/redact.js'
 import axiosError from './util/axios-error-handler.js'
 import buttonBuilder from './util/button-builder.js'
 import configUserData from './util/get-user-data.js'            // cloud-init user_data + codespace.env (metadata + user env)
-import parseEnvVars from './util/parse-env-vars.js'             // KEY=VALUE textarea -> { env, errors }
+import parseEnvVars from './util/parse-env-vars.js'             // KEY=VALUE textarea (profile modal) -> { env, errors }
 import parseRepo from './util/parse-repo.js'                    // repo input -> canonical https .git URL
 import { generateCdeToken } from './util/token-generator.js'
 import { formatCreatedDate, sortByCreatedAtAsc } from './util/format-date.js'
@@ -139,20 +139,22 @@ These are load-bearing. Do not change without understanding the impact.
   → updates modal via vmCreateModal({ regions, images, servers: [], regionStats: null, profiles })
      (profile names also stashed in privateMetaData so the picker survives re-render)
 
-Modal fields: [profile picker if any] · region · [Proxmox stats] · image · server type
-              · per-VM {description, repo} · shared env-vars textarea · single-click
+Modal fields: [profile picker if any, else a "/vm profile new" hint] · region · [Proxmox stats]
+              · image · server type · per-VM {description, repo} · single-click
+              (NO env textarea — env vars come only from the selected profile)
 
 User selects a region (dispatch action fires)
   → vm-region.js: re-fetches /v1/regions + /v1/get-images
   → finds selected regionObj, extracts instance types + regionStats
-  → re-seeds image, descriptions, repos, env, single-click, profile from view.state.values
-     (so switching regions does NOT wipe typed input; server type intentionally resets)
+  → re-seeds image, descriptions, repos, single-click, profile from view.state.values
+     (so switching regions does NOT wipe input; server type intentionally resets)
   → updates modal via vmCreateModal({ ..., regionStats, profiles, selected* })
 
 User submits modal
-  → vm-create-modal.js: parse + validate env (parse-env-vars) and each repo (parse-repo)
-     and reject placeholder region/image/server — BEFORE ack(); inline errors on failure
-  → if a profile was picked: getProfile() and merge its env UNDER typed env (typed wins)
+  → vm-create-modal.js: validate each repo (parse-repo) and reject placeholder
+     region/image/server — BEFORE ack(); inline errors on failure
+  → if a profile was picked: getProfile() and use its env as the ONLY env source
+     (abort creation if it can't be loaded); no profile → a plain VM with no env
   → calls libvirt.createServer() per VM (parallel for batch; batch=true suppresses per-VM chatter)
   → createServer writes codespace.env (metadata + user env), tags clone_repo, posts result
      (single: Server/Profile/Repo/Access; batch: one summary line per VM)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A Slack bot (Bolt.js, HTTP mode) that lets developers provision and manage VMs via slash commands. It talks to a [GlueOps Provisioner](https://github.com/GlueOps/provisioner) REST API that supports two backends: **libvirt** (bare-metal hypervisors over SSH) and **Proxmox VE** (via the Proxmox REST API). Users create, list, start, stop, delete, and edit VMs entirely through Slack modals and ephemeral messages.
 
-On create, a developer can also inject custom **environment variables**, auto-clone a **GitHub repo**, and apply a saved **profile** — a reusable bundle of env vars stored per-user in S3, encrypted at rest. Profiles are managed with `/vm profile` (list / new / delete, with an Edit button).
+On create, a developer can auto-clone a **GitHub repo** and apply a saved **profile** — a reusable bundle of env vars stored per-user in S3, encrypted at rest. **Environment variables are set only via profiles** (the create modal has no env textarea). Profiles are managed with `/vm profile` (list / new / delete, with Edit/Copy buttons).
 
 ## Development Commands
 
@@ -36,7 +36,7 @@ There are no automated tests or linting tools configured.
 - `get-user-data.js` — builds cloud-init `user_data` for new VMs. Writes `/etc/glueops/codespace.env`: platform metadata as `GLUEOPS_CDE_*`, user-supplied env vars **verbatim**.
 - `profile-store.js` — S3-backed store for per-user VM profiles (env-var bundles). Whole document encrypted at rest; the S3 object key is a keyed HMAC of the email. Every S3 call is bounded by `PROFILES_S3_TIMEOUT_MS`.
 - `profile-crypto.js` — AES-256-GCM `encrypt`/`decrypt` of the profile document + keyed `hashEmail()` for the object key. Guards against a missing email.
-- `parse-env-vars.js` — parses the `KEY=VALUE` env textarea; reports malformed lines for inline modal errors.
+- `parse-env-vars.js` — parses the `KEY=VALUE` env textarea (now in the **profile** create/edit modal); reports malformed lines for inline modal errors.
 - `parse-repo.js` — validates + normalises a repo-to-clone input to a canonical `https://github.com/owner/repo.git` URL.
 - `redact.js` — strips secrets from log records; wired into `logger.js`.
 - `token-generator.js` — generates CDE tokens for single-click experience.
@@ -46,9 +46,9 @@ There are no automated tests or linting tools configured.
 - `axios-error-handler.js` — normalises axios errors for logging.
 
 **UI builders** (`user-interface/modals/`):
-- `vm-create.js` — VM creation modal. Accepts `regionStats` for the Proxmox capacity/load context block, an optional profile picker, per-VM description + repo inputs, and a shared env-vars textarea. Takes initial-value params so a region change rebuilds it without losing typed input.
+- `vm-create.js` — VM creation modal. Accepts `regionStats` for the Proxmox capacity/load context block, an optional profile picker (or a hint to run `/vm profile new` when the user has none), and per-VM description + repo inputs. **No env textarea** — env vars come from the selected profile. Takes initial-value params so a region change rebuilds it without losing input.
 - `vm-edit.js` — VM description edit modal.
-- `vm-profile.js` — create/update a VM profile (name + env vars). The name is locked (rendered as static text) when editing.
+- `vm-profile.js` — create/update a VM profile (name + env vars); a new profile pre-seeds a recommended-keys guidance template in the env textarea. The name is locked (rendered as static text) when editing.
 
 ## Key Patterns
 
@@ -68,9 +68,9 @@ There are no automated tests or linting tools configured.
 
 **All responses are ephemeral:** `chat.postEphemeral` is used throughout — responses are only visible to the triggering user.
 
-**Custom env vars & repo clone:** the create modal has an optional env-vars textarea (`KEY=VALUE` per line) and a per-VM repo field. Env is parsed by `parse-env-vars.js` and written **verbatim** to `codespace.env` (dev apps expect `GITHUB_TOKEN`, not `GLUEOPS_CDE_GITHUB_TOKEN`); the `GLUEOPS_CDE_` prefix is reserved for platform metadata, and user keys in that namespace are dropped. The repo is validated/normalised by `parse-repo.js`, stored on the VM tag `clone_repo`, emitted as `GLUEOPS_CDE_CLONE_REPO`, and shown in the create confirmation and `/vm list`.
+**Custom env vars & repo clone:** env vars are defined in a **profile** (not on the create modal, which has only a profile picker + a per-VM repo field). A profile's env (`KEY=VALUE` per line) is parsed by `parse-env-vars.js` and written **verbatim** to `codespace.env` (dev apps expect `GITHUB_TOKEN`, not `GLUEOPS_CDE_GITHUB_TOKEN`); the `GLUEOPS_CDE_` prefix is reserved for platform metadata, and user keys in that namespace are dropped. The repo is validated/normalised by `parse-repo.js`, stored on the VM tag `clone_repo`, emitted as `GLUEOPS_CDE_CLONE_REPO`, and shown in the create confirmation and `/vm list`.
 
-**VM profiles (S3 + encryption):** a profile is a per-user, named bundle of env vars stored as one JSON document per user in S3 (`profile-store.js`). The whole document is encrypted with AES-256-GCM (`profile-crypto.js`) using `PROFILES_ENCRYPTION_KEY`, and the S3 object key is a keyed HMAC of the normalized email — so the bucket reveals neither contents nor identity. Encryption is **client-side** (Node `crypto`), not S3 SSE. The create modal shows an optional profile picker (only when the user has profiles, never a default); on submit the profile's env is merged **under** anything typed (typed wins). Profiles are managed via `/vm profile` + Edit/Delete/New buttons; **editing overwrites in place** (the name is locked). All `PROFILES_S3_*` + `PROFILES_ENCRYPTION_KEY` vars are **required at startup** (`requireProfilesConfig()` in `app.js`).
+**VM profiles (S3 + encryption):** a profile is a per-user, named bundle of env vars stored as one JSON document per user in S3 (`profile-store.js`). The whole document is encrypted with AES-256-GCM (`profile-crypto.js`) using `PROFILES_ENCRYPTION_KEY`, and the S3 object key is a keyed HMAC of the normalized email — so the bucket reveals neither contents nor identity. Encryption is **client-side** (Node `crypto`), not S3 SSE. The create modal shows an optional profile picker (only when the user has profiles, never a default; otherwise a hint to run `/vm profile new`); on submit the selected profile's env is the **only** env source, and a profile that can't be loaded aborts creation (never a silently secretless VM). Profiles are managed via `/vm profile` + Edit/Delete/New buttons; **editing overwrites in place** (the name is locked). All `PROFILES_S3_*` + `PROFILES_ENCRYPTION_KEY` vars are **required at startup** (`requireProfilesConfig()` in `app.js`).
 
 **Log redaction:** `logger.js` runs every record through `redact.js`, which strips secret-bearing fields (by key name and by long base64 blobs) — including the cloud-init `user_data` if the provisioner echoes it in an error. No call site can leak secrets to logs.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Slack bot (Bolt.js, HTTP mode) for provisioning and managing developer VMs via slash commands. Talks to the [GlueOps Provisioner](https://github.com/GlueOps/provisioner) API, which supports both **libvirt** (bare-metal) and **Proxmox VE** backends.
 
-On create, developers can inject custom environment variables, auto-clone a GitHub repo, and apply reusable **profiles** — bundles of env vars saved per-user in S3 and encrypted at rest. See [VM Profiles & Environment](#vm-profiles--environment).
+On create, developers can auto-clone a GitHub repo and apply reusable **profiles** — bundles of env vars saved per-user in S3 and encrypted at rest, and the only way to set custom environment variables. See [VM Profiles & Environment](#vm-profiles--environment).
 
 > **For developers and AI agents:** See [CLAUDE.md](CLAUDE.md) and [.ai/AGENTS.md](.ai/AGENTS.md) for architecture, key patterns, invariants, and module reference.
 
@@ -80,9 +80,8 @@ You can find an example ACL file in this [repo](tailscale-acls.json).
 
 When creating a VM, developers can:
 
-- **Set environment variables** — a `KEY=VALUE` textarea in the create modal, written verbatim into the VM's `/etc/glueops/codespace.env`.
 - **Clone a GitHub repo** — a per-VM field accepting `owner/repo`, `github.com/owner/repo`, or a full/`.git`/browser URL (normalised to a canonical clone URL).
-- **Apply a profile** — a saved, reusable bundle of env vars. Manage profiles with `/vm profile` (list), `/vm profile new`, `/vm profile delete <name>`, and the **Edit**/**Delete** buttons. Picking a profile at create time merges its env under anything typed (typed wins).
+- **Apply a profile** — a saved, reusable bundle of env vars, and the **only** way to set environment variables (there's no env textarea on the create modal). The profile's `KEY=VALUE` vars are written verbatim into the VM's `/etc/glueops/codespace.env`. Manage profiles with `/vm profile` (list), `/vm profile new`, `/vm profile delete <name>`, and the **Edit**/**Copy**/**Delete** buttons. Picking a profile at create time applies its env vars; if you have no profiles, the create modal points you to `/vm profile new`.
 
 ### Profiles storage & encryption
 

--- a/listeners/actions/vm-region.js
+++ b/listeners/actions/vm-region.js
@@ -99,7 +99,6 @@ export default async function vmRegionCallback({ ack, body, client }) {
   const profiles = parsedMetaData.profiles || [];
   const selectedProfile = st.profile?.profile?.selected_option?.value || null;
   const selectedImage = st.image?.image?.selected_option?.value || null;
-  const envText = st.env_vars?.env_vars?.value || '';
   const singleClick = st.launchMode?.singleClickExperience?.selected_options?.some(
     o => o.value === 'single_click_enabled'
   ) ?? false;
@@ -115,7 +114,7 @@ export default async function vmRegionCallback({ ack, body, client }) {
     view_id: body.view.id,
     view: vmModal({
       regions, images, servers, metaData, vmCount, regionStats, selectedRegion,
-      profiles, selectedProfile, selectedImage, descriptions, cloneRepos, envText, singleClick
+      profiles, selectedProfile, selectedImage, descriptions, cloneRepos, singleClick
     })
   });
 }

--- a/listeners/views/vm-create-modal.js
+++ b/listeners/views/vm-create-modal.js
@@ -1,5 +1,4 @@
 import libvirt from '../../util/libvirt/libvirt-server.js';
-import parseEnvVars from '../../util/parse-env-vars.js';
 import parseRepo from '../../util/parse-repo.js';
 import { getProfile } from '../../util/profile-store.js';
 import logger from '../../util/logger.js';
@@ -11,8 +10,8 @@ export default async function vmCreateModalCallback({ ack, view, body, client })
   const metaData = JSON.parse(view.private_metadata);
   const vmCount = metaData.vmCount || 1;
 
-  // Validate env + per-VM repos BEFORE acking so problems surface as inline modal errors
-  // (keyed by block_id) rather than being silently dropped.
+  // Validate region/image/server + per-VM repos BEFORE acking so problems surface as inline
+  // modal errors (keyed by block_id) rather than being silently dropped.
   const errors = {};
 
   // Optional-chain every read: if this fires against a transient loading/error view (which
@@ -25,9 +24,6 @@ export default async function vmCreateModalCallback({ ack, view, body, client })
   if (!selectedRegion || selectedRegion === 'placeholder') errors.region = 'Please select a region.';
   if (!selectedImage || selectedImage === 'placeholder') errors.image = 'Please select an image.';
   if (!selectedServer || selectedServer === 'placeholder') errors.server = 'Please pick a region first, then a server type.';
-
-  const { env: userEnv, errors: envErrors } = parseEnvVars(values.env_vars?.env_vars?.value || '');
-  if (envErrors.length > 0) errors.env_vars = envErrors.join('  •  ').slice(0, 1900);
 
   // Extract per-VM description + repo. Repo is validated and normalised to a canonical
   // https://github.com/owner/repo.git URL; blank is allowed (optional).
@@ -51,12 +47,12 @@ export default async function vmCreateModalCallback({ ack, view, body, client })
     opt => opt.value === 'single_click_enabled'
   ) ?? false;
 
-  // If a profile was picked, merge its env under what the user typed (typed wins). A
-  // profile that can't be loaded ABORTS creation — we never create a VM that's silently
-  // missing the secrets the developer selected. Invariant: VM created + profile selected
-  // ⟹ profile applied.
+  // Env vars come solely from the selected profile (the create modal has no env input). No
+  // profile → a plain VM with no injected env. A selected profile that can't be loaded
+  // ABORTS creation — we never create a VM that's silently missing the secrets the developer
+  // selected. Invariant: VM created + profile selected ⟹ profile applied.
   const selectedProfile = values.profile?.profile?.selected_option?.value || null;
-  let finalEnv = userEnv;
+  let finalEnv = {};
   let profileName = null;
   if (selectedProfile) {
     let profile;
@@ -80,7 +76,7 @@ export default async function vmCreateModalCallback({ ack, view, body, client })
       });
       return;
     }
-    finalEnv = { ...profile.env, ...userEnv };
+    finalEnv = profile.env;
     profileName = selectedProfile;
   }
 

--- a/user-interface/modals/vm-create.js
+++ b/user-interface/modals/vm-create.js
@@ -1,44 +1,13 @@
 import { Modal, Blocks, Elements, Bits } from 'slack-block-builder';
 
-// Pre-seeded into the env-vars textarea on first open (GlueOps-specific, hardcoded).
-// EVERY line is a comment — nothing here sets a value. That's deliberate: a value-bearing
-// default would win over a selected profile in the create merge ({...profile, ...typed})
-// and silently clobber the profile's own version of that key. The recommended keys are
-// shown commented-out (AutoGlue URL defaults visible, grouped by environment); a dev opts
-// in by uncommenting, and the runtime defaults live on the VM (cde-init / cde-boot).
-const DEFAULT_ENV_TEXT = [
-  '# Uncomment a line (remove the leading "# ") and set its value to use it.',
-  '# Blank lines and comments are ignored.',
-  '#',
-  '# GITHUB_TOKEN — required for PRIVATE repo clones and gh auth; public repos work without it.',
-  '# GITHUB_TOKEN=',
-  '#',
-  '# AutoGlue SSH (gluekube_ssh): to auto-create a profile, uncomment BOTH its URL and token',
-  '# (a profile is seeded only when the URL and token are both set).',
-  '#   prod:',
-  '# GLUEKUBE_SSH_AUTOGLUE_PROD_URL=https://autoglue.glueopshosted.com/api/v1',
-  '# GLUEKUBE_SSH_AUTOGLUE_PROD_TOKEN=',
-  '#   nonprod:',
-  '# GLUEKUBE_SSH_AUTOGLUE_NONPROD_URL=https://autoglue.glueopshosted.rocks/api/v1',
-  '# GLUEKUBE_SSH_AUTOGLUE_NONPROD_TOKEN=',
-  '#',
-  '# CDE_SETUP_SCRIPT runs at CDE start. Left unset, the default bootstrap `cde-init` runs',
-  '# (gh auth + clone your repo + set up AutoGlue). Uncomment + change it to override:',
-  '#   <a command>       = run it instead, e.g.  curl setup.example.com | zsh',
-  '#   base64:<encoded>  = a complex/multi-line script  (<script> | base64 -w0)',
-  '#                       e.g.  base64:Y2RlLWluaXQ=  decodes to  cde-init',
-  '#   true              = skip setup entirely',
-  '# CDE_SETUP_SCRIPT=cde-init',
-].join('\n');
-
-// `envText` is undefined on first open → pre-seed DEFAULT_ENV_TEXT. On a region re-render,
-// vm-region.js passes the current textarea value (a string, possibly empty), shown as-is so
-// a dev who edited or cleared it isn't reset back to the default.
-export default function vmCreateModal({ regions = [], images = [], servers = [], metaData, vmCount = 1, regionStats = null, selectedRegion = null, profiles = [], selectedProfile = null, selectedImage = null, selectedServer = null, descriptions = [], cloneRepos = [], envText, singleClick = false } = {}) {
+// Env vars are NOT entered on this modal — they come solely from a selected profile
+// (managed via `/vm profile`; the recommended-keys guidance now lives in the profile-create
+// modal). This modal only picks a profile; the merge happens in listeners/views/vm-create-modal.js.
+export default function vmCreateModal({ regions = [], images = [], servers = [], metaData, vmCount = 1, regionStats = null, selectedRegion = null, profiles = [], selectedProfile = null, selectedImage = null, selectedServer = null, descriptions = [], cloneRepos = [], singleClick = false } = {}) {
   const title = vmCount > 1 ? `Create ${vmCount} VMs` : 'Create VM';
 
   // Per-VM fields: each VM gets its own description and repo to clone (different VMs are
-  // usually different repos). Region/image/size/env stay shared across the batch.
+  // usually different repos). Region/image/size and any selected profile stay shared.
   // initialValue re-seeds anything the user already typed when the modal is rebuilt (e.g.
   // on region change), so switching regions doesn't wipe their input.
   const perVmBlocks = [];
@@ -63,9 +32,10 @@ export default function vmCreateModal({ regions = [], images = [], servers = [],
 
   return Modal({ title, submit: 'Submit', callbackId: 'vm-create-modal', privateMetaData: metaData })
     .blocks(
-      // Optional profile picker — shown only when the user has saved profiles. Selecting
-      // one applies its env vars on submit (merged under anything typed below). No default
-      // selection; never required.
+      // Optional profile picker — the ONLY way to inject env vars. Shown when the user has
+      // saved profiles; selecting one applies its env vars on submit. No default selection;
+      // never required (no profile = a plain VM with no injected env). When the user has no
+      // profiles, a hint points them to `/vm profile new`.
       ...(profiles.length > 0
         ? [Blocks.Input({ label: 'Profile', blockId: 'profile', optional: true }).element(
             Elements.StaticSelect({ actionId: 'profile' })
@@ -77,7 +47,9 @@ export default function vmCreateModal({ regions = [], images = [], servers = [],
                   : undefined
               )
           )]
-        : []),
+        : [Blocks.Context().elements(
+            'No profiles yet — run `/vm profile new` to save environment variables (e.g. `GITHUB_TOKEN`) you can apply here.'
+          )]),
 
       Blocks.Input({ label: 'Region', blockId: 'region' })
       .dispatchAction(true)
@@ -136,14 +108,6 @@ export default function vmCreateModal({ regions = [], images = [], servers = [],
       ),
 
       ...perVmBlocks,
-
-      Blocks.Input({ label: vmCount > 1 ? `Environment variables (applied to all ${vmCount} VMs)` : 'Environment variables', blockId: 'env_vars', optional: true }).element(
-        Elements.TextInput({ actionId: 'env_vars' })
-          .multiline(true)
-          .placeholder('One per line, KEY=VALUE\nGITHUB_TOKEN=ghp_...\nDATABASE_URL=postgres://...')
-          .initialValue((envText === undefined ? DEFAULT_ENV_TEXT : envText) || undefined)
-          .maxLength(3000)
-      ),
 
       Blocks.Input({ label: 'Launch Mode', blockId: 'launchMode', optional: true }).element(
         Elements.Checkboxes({ actionId: 'singleClickExperience' })

--- a/user-interface/modals/vm-profile.js
+++ b/user-interface/modals/vm-profile.js
@@ -12,6 +12,34 @@ import { Modal, Blocks, Elements } from 'slack-block-builder';
         `name` arg (copy suggests "<source>-copy"; new leaves it blank).
     `envText` pre-fills the env textarea (edit + copy).
 */
+// Recommended-keys guidance, pre-seeded into the env textarea for a NEW profile (not edit/
+// copy, which show real values). Every line is a comment/blank, so an untouched template
+// saves as an empty profile. This is where the guidance lives now that the create modal has
+// no env input. Mirrors the grouped/commented style the create modal used to show.
+const PROFILE_ENV_TEMPLATE = [
+  '# One KEY=VALUE per line. Uncomment a line (remove the leading "# ") and set its value.',
+  '# Blank lines, comments, and a blank KEY= are ignored.',
+  '#',
+  '# GITHUB_TOKEN — required for PRIVATE repo clones and gh auth; public repos work without it.',
+  '# GITHUB_TOKEN=',
+  '#',
+  '# AutoGlue SSH (gluekube_ssh): to auto-create a profile on the VM, uncomment BOTH a URL',
+  '# and its token (seeded only when both are set).',
+  '#   prod:',
+  '# GLUEKUBE_SSH_AUTOGLUE_PROD_URL=https://autoglue.glueopshosted.com/api/v1',
+  '# GLUEKUBE_SSH_AUTOGLUE_PROD_TOKEN=',
+  '#   nonprod:',
+  '# GLUEKUBE_SSH_AUTOGLUE_NONPROD_URL=https://autoglue.glueopshosted.rocks/api/v1',
+  '# GLUEKUBE_SSH_AUTOGLUE_NONPROD_TOKEN=',
+  '#',
+  '# CDE_SETUP_SCRIPT runs at CDE start. Left unset, the default bootstrap `cde-init` runs',
+  '# (gh auth + clone your repo + set up AutoGlue). Uncomment + change it to override:',
+  '#   <a command>       = run it instead, e.g.  curl setup.example.com | zsh',
+  '#   base64:<encoded>  = a complex/multi-line script  (<script> | base64 -w0)',
+  '#   true              = skip setup entirely',
+  '# CDE_SETUP_SCRIPT=cde-init',
+].join('\n');
+
 export default function vmProfileModal({ name = '', envText = '', metaData } = {}) {
   const meta = metaData ? JSON.parse(metaData) : {};
   const editing = Boolean(meta.name);
@@ -36,7 +64,8 @@ export default function vmProfileModal({ name = '', envText = '', metaData } = {
         Elements.TextInput({ actionId: 'env_vars' })
           .multiline(true)
           .placeholder('One per line, KEY=VALUE\nGITHUB_TOKEN=ghp_...\nDATABASE_URL=postgres://...')
-          .initialValue(envText || undefined)
+          // New profile → seed the guidance template; edit/copy → show the real env values.
+          .initialValue(envText || (editing ? undefined : PROFILE_ENV_TEMPLATE))
           .maxLength(3000)
       )
     )


### PR DESCRIPTION
## What

Removes the free-form env-vars textarea from the `/vm create` modal. Environment variables now come **solely from a selected profile** (managed via `/vm profile`). Profile selection stays **optional** — a VM with no profile is a plain VM with no injected env.

## Why

The create modal showed a pre-seeded env template right next to the profile picker, which read as "these belong to the selected profile" and spread secret entry across two places. Making profiles the only env source centralizes all secrets in the encrypted S3 profile store and de-clutters a very tall modal.

## Changes

- `user-interface/modals/vm-create.js` — drop `DEFAULT_ENV_TEXT` + the `env_vars` input + the `envText` param; when the user has **no** profiles, show a Context hint to run `/vm profile new`.
- `listeners/views/vm-create-modal.js` — the selected profile's env is the only source (no merge with typed values); a profile that can't be loaded still aborts creation (no silently-secretless VM).
- `listeners/actions/vm-region.js` — remove the now-dead `envText` plumbing from the region re-render.
- `user-interface/modals/vm-profile.js` — the profile env textarea pre-seeds the recommended-keys guidance template for **new** profiles only (edit/copy show real values).
- Docs: `CLAUDE.md`, `README.md`, `.ai/AGENTS.md`.

## Reviewed tradeoffs (accepted)

DevX + UX reviews recommended *demoting* rather than removing the textarea. We chose full removal, knowingly accepting: no inline per-VM override of a profile key; no one-off/ephemeral env var (any env var must become a saved profile); and a mid-create dead-end if a dev realizes they need a var but has no profile (close create → `/vm profile new` → restart). Mitigations (in-modal profile creation, save-as-profile) intentionally not built.

## Verification

In `node:24-alpine`: create modal builds with no `env_vars` block (with and without profiles); shows the picker when profiles exist and the hint when not; new-profile modal seeds the template while edit/copy show real values; `parseEnvVars` no longer imported by the create handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)