### PR TITLE
feat: adapt to waggle-backed proxmox regions

### DIFF
--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -4,7 +4,8 @@ Operational reference for AI agents working in this repo. Read alongside CLAUDE.
 
 ## Connected Repos
 
-- **[provisioner](https://github.com/GlueOps/provisioner)** — the backend API this bot talks to. Its [`.ai/AGENTS.md`](https://github.com/GlueOps/provisioner/blob/main/.ai/AGENTS.md) documents the full VM lifecycle, Proxmox region name format, how `(Over Allocated)` is appended to instance types, cloud-init flow, and all endpoint behaviour.
+- **[provisioner](https://github.com/GlueOps/provisioner)** — the backend API this bot talks to. Its [`.ai/AGENTS.md`](https://github.com/GlueOps/provisioner/blob/main/.ai/AGENTS.md) documents the full VM lifecycle, the Waggle-backed Proxmox region model (one region per Waggle datacenter; Waggle picks the hypervisor), cloud-init flow, and all endpoint behaviour.
+- **[waggle](https://github.com/glueops/waggle)** — the placement oracle behind Proxmox regions. Instance types are Waggle *slots*; the provisioner pre-filters them against Waggle's hypervisor ledger so the bot only ever sees placeable ones. The bot never talks to Waggle directly — only through the provisioner.
 
 ---
 
@@ -55,7 +56,7 @@ All calls go to `process.env.PROVISIONER_URL` with `Authorization: ${process.env
 
 | Endpoint | Method | Called from | Purpose |
 |---|---|---|---|
-| `/v1/regions` | GET | `vm.js`, `vm-region.js` | List available regions + instance types. Proxmox regions include capacity/load fields. |
+| `/v1/regions` | GET | `vm.js`, `vm-region.js` | List available regions + instance types. Proxmox regions list only currently-placeable Waggle slots. |
 | `/v1/get-images` | GET | `vm.js`, `vm-region.js` | List available VM images |
 | `/v1/create` | POST | `libvirt-server.js` | Create a VM |
 | `/v1/list` | GET | `libvirt-server.js` | List all VMs (filtered to caller's email client-side) |
@@ -63,6 +64,8 @@ All calls go to `process.env.PROVISIONER_URL` with `Authorization: ${process.env
 | `/v1/stop` | POST | `libvirt-server.js` | Stop a VM |
 | `/v1/delete` | DELETE | `libvirt-server.js` | Delete a VM |
 | `/v1/edit-tags` | POST | `libvirt-server.js` | Update VM tags/description |
+
+Failure messages append `Reason: <detail>` when the provisioner returns a **4xx** with a string `detail` body (e.g. 409 region-at-capacity, 404 VM-not-found) — see `provisionerDetail` in `libvirt-server.js`. 5xx bodies (generic boilerplate) and FastAPI validation arrays are never surfaced.
 
 ### `/v1/regions` response shape
 
@@ -78,18 +81,18 @@ All calls go to `process.env.PROVISIONER_URL` with `Authorization: ${process.env
     "cpu_pct": null, "ram_pct": null
   },
   {
-    "region_name": "proxmox-cluster-1-pve-node-01",
+    "region_name": "proxmox-cluster-1",
     "enabled": true,
-    "available_instance_types": [{ "instance_type": "2vcpu-8gb-32ssd (Over Allocated)", "vcpus": 2, "memory_mb": 8192, "storage_mb": 32000 }],
-    "total_vcpus": 40, "free_vcpus": 32,
-    "total_memory_gb": 128, "free_memory_gb": 96,
-    "total_storage_gb": 2000, "free_storage_gb": 1800,
-    "cpu_pct": 15, "ram_pct": 25
+    "available_instance_types": [{ "instance_type": "2vcpu-8gb-32ssd", "vcpus": 2, "memory_mb": 8192, "storage_mb": 32768 }],
+    "total_vcpus": null, "free_vcpus": null,
+    "total_memory_gb": null, "free_memory_gb": null,
+    "total_storage_gb": null, "free_storage_gb": null,
+    "cpu_pct": null, "ram_pct": null
   }
 ]
 ```
 
-Libvirt regions have `null` for all capacity/load fields. Proxmox regions have integers.
+The capacity fields are always `null` (legacy schema leftovers) — the bot ignores them. A Proxmox region is one Waggle datacenter (whole cluster) and its `available_instance_types` are the Waggle slots that can *currently* be placed: the provisioner pre-filters against Waggle's hypervisor ledger, so a listed slot is creatable right now.
 
 ---
 
@@ -103,13 +106,13 @@ These are load-bearing. Do not change without understanding the impact.
 
 3. **User identity is always resolved to email** via `client.users.info({ user: body.user.id })`. The email is stored as `owner` in VM tags. `listServers` filters VMs client-side by matching `server.tags.owner === userEmail`.
 
-4. **`regionStats` is `null` for libvirt, populated for Proxmox** — the guard `regionObj.cpu_pct != null` in `vm-region.js` detects which backend a region belongs to. The modal's `regionStats != null` check controls whether the capacity/load context block renders. Do not change this guard without testing both backends.
+4. **No capacity UI — the instance-type list IS the availability signal** — the provisioner only lists instance types that can actually be placed (Proxmox: Waggle slots with room on some hypervisor). The bot renders the list as-is; do not add client-side capacity math or re-introduce a stats block from the always-`null` capacity fields.
 
-5. **`(Over Allocated)` suffix passes through unchanged** — the provisioner appends ` (Over Allocated)` to instance type names when a node is under-resourced. The slackbot displays this label as-is, sends it back to the provisioner as the `instance_type` value, and writes it verbatim to `GLUEOPS_CDE_INSTANCE_TYPE` in the cloud-init env file. The provisioner strips the suffix before VM creation. Do not strip it in the slackbot.
+5. **Instance-type *values* round-trip unchanged; *labels* are enriched** — for Proxmox regions the `instance_type` value is a Waggle slot name; the provisioner resolves it back to a slot at create time. The dropdown option **value** is the bare slot name and round-trips verbatim (also written verbatim to `GLUEOPS_CDE_INSTANCE_TYPE` in the cloud-init env file); the option **label** appends specs from the payload — `name (N vCPU • N GB RAM • N GB disk)` — with a 75-char Slack-limit fallback to the bare name (`vm-create.js`). If a datacenter is full, `/v1/create` fails cleanly (Waggle placement is all-or-nothing) — there is no "(Over Allocated)" suffix.
 
 6. **`\n` in a single `Bits.Mrkdwn()` element for multi-line context blocks** — Slack context blocks render multiple `elements` inline (side-by-side). To get separate lines, use a single `Bits.Mrkdwn()` element with `\n` separating the lines. Do not split into separate elements.
 
-7. **Region names are stable identifiers** — Proxmox region names are bare `{cluster}-{node}` strings (e.g. `proxmox-cluster-1-pve-node-01`). Libvirt region names are static strings from config. Region names are used as both the dropdown label (`text`) and the value (`value`) sent back to the provisioner. They round-trip unchanged.
+7. **Region names are stable identifiers** — a Proxmox region name is the Waggle datacenter / cluster name (e.g. `proxmox-cluster-1`); the specific hypervisor is chosen by Waggle at create time and never appears in the region name. Libvirt region names are static strings from config. Region names are used as both the dropdown label (`text`) and the value (`value`) sent back to the provisioner. They round-trip unchanged.
 
 8. **Modal state passes via `privateMetaData`** — JSON-stringified. Set on modal open, read in view handlers via `JSON.parse(view.private_metadata)`. Contains at minimum `{ channel_id, vmCount }`; the create modal also carries `profiles` (names, so the picker survives re-render); edit flows add `{ serverName, region, tags }`; the profile modal carries `{ channel_id, name }` where `name` present ⇒ editing.
 
@@ -136,19 +139,22 @@ These are load-bearing. Do not change without understanding the impact.
   → vm.js: opens loading modal
   → fetches /v1/regions + /v1/get-images in parallel
   → loads the user's profile names from S3 (best-effort)
-  → updates modal via vmCreateModal({ regions, images, servers: [], regionStats: null, profiles })
+  → updates modal via vmCreateModal({ regions, images, servers: [], profiles })
      (profile names also stashed in privateMetaData so the picker survives re-render)
 
-Modal fields: [profile picker if any, else a "/vm profile new" hint] · region · [Proxmox stats]
+Modal fields: [profile picker if any, else a "/vm profile new" hint] · region
               · image · server type · per-VM {description, repo} · single-click
               (NO env textarea — env vars come only from the selected profile)
 
 User selects a region (dispatch action fires)
   → vm-region.js: re-fetches /v1/regions + /v1/get-images
-  → finds selected regionObj, extracts instance types + regionStats
+  → finds selected regionObj, extracts its instance types (already pre-filtered
+     by the provisioner to what's currently placeable); zero instance types for a
+     selected region renders a ":warning: region is at capacity" context note
+     (submit stays blocked via the 'placeholder' option value)
   → re-seeds image, descriptions, repos, single-click, profile from view.state.values
      (so switching regions does NOT wipe input; server type intentionally resets)
-  → updates modal via vmCreateModal({ ..., regionStats, profiles, selected* })
+  → updates modal via vmCreateModal({ ..., profiles, selected* })
 
 User submits modal
   → vm-create-modal.js: validate each repo (parse-repo) and reject placeholder

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Project Does
 
-A Slack bot (Bolt.js, HTTP mode) that lets developers provision and manage VMs via slash commands. It talks to a [GlueOps Provisioner](https://github.com/GlueOps/provisioner) REST API that supports two backends: **libvirt** (bare-metal hypervisors over SSH) and **Proxmox VE** (via the Proxmox REST API). Users create, list, start, stop, delete, and edit VMs entirely through Slack modals and ephemeral messages.
+A Slack bot (Bolt.js, HTTP mode) that lets developers provision and manage VMs via slash commands. It talks to a [GlueOps Provisioner](https://github.com/GlueOps/provisioner) REST API that supports two backends: **libvirt** (bare-metal hypervisors over SSH) and **Waggle-backed Proxmox VE** ([Waggle](https://github.com/glueops/waggle) is the placement oracle that decides which Proxmox hypervisor each VM lands on; the provisioner then creates the VM via the Proxmox REST API). Users create, list, start, stop, delete, and edit VMs entirely through Slack modals and ephemeral messages.
 
 On create, a developer can auto-clone a **GitHub repo** and apply a saved **profile** — a reusable bundle of env vars stored per-user in S3, encrypted at rest. **Environment variables are set only via profiles** (the create modal has no env textarea). Profiles are managed with `/vm profile` (list / new / delete, with Edit/Copy buttons).
 
@@ -46,7 +46,7 @@ There are no automated tests or linting tools configured.
 - `axios-error-handler.js` — normalises axios errors for logging.
 
 **UI builders** (`user-interface/modals/`):
-- `vm-create.js` — VM creation modal. Accepts `regionStats` for the Proxmox capacity/load context block, an optional profile picker (or a hint to run `/vm profile new` when the user has none), and per-VM description + repo inputs. **No env textarea** — env vars come from the selected profile. Takes initial-value params so a region change rebuilds it without losing input.
+- `vm-create.js` — VM creation modal. Accepts an optional profile picker (or a hint to run `/vm profile new` when the user has none) and per-VM description + repo inputs. **No env textarea** — env vars come from the selected profile. Takes initial-value params so a region change rebuilds it without losing input.
 - `vm-edit.js` — VM description edit modal.
 - `vm-profile.js` — create/update a VM profile (name + env vars); a new profile pre-seeds a recommended-keys guidance template in the env textarea. The name is locked (rendered as static text) when editing.
 
@@ -60,9 +60,7 @@ There are no automated tests or linting tools configured.
 
 **Dispatch action on region select:** The region dropdown in `vm-create.js` has `.dispatchAction(true)`. When a user picks a region, Slack fires the `region` action, handled by `listeners/actions/vm-region.js`. This re-fetches `/v1/regions` and `/v1/get-images` fresh and updates the modal in-place with instance types and — for Proxmox regions — a capacity/load context block.
 
-**Proxmox regionStats:** `/v1/regions` returns capacity/load as separate fields on Proxmox region objects (`total_vcpus`, `free_vcpus`, `total_memory_gb`, `free_memory_gb`, `total_storage_gb`, `free_storage_gb`, `cpu_pct`, `ram_pct`). Libvirt regions return `null` for all these fields. `vm-region.js` builds a `regionStats` object when `cpu_pct != null`, passes it to the modal builder, which renders a three-line context block with emoji-coded load. When `regionStats` is `null` (libvirt), the context block is omitted entirely.
-
-**Over Allocated instance types:** The provisioner appends ` (Over Allocated)` to instance type names when a node's free capacity is less than the type requires. The slackbot passes this string through as-is — as the dropdown label, as the value sent back to the provisioner on create, and as `GLUEOPS_CDE_INSTANCE_TYPE` in the cloud-init env file. The provisioner strips the suffix before lookup.
+**Proxmox instance types are pre-filtered by availability:** each Proxmox region is one Waggle datacenter (a whole cluster — Waggle picks the node), and its `available_instance_types` from `/v1/regions` lists only the Waggle slots that can currently be placed. The bot renders the list with no capacity/load UI — if a slot is in the dropdown, it can be created right now. Dropdown labels append the slot's specs from the payload (`2vcpu-8gb-32ssd (2 vCPU • 8 GB RAM • 32 GB disk)`), while the option value stays the bare slot name and round-trips to the provisioner verbatim. If capacity races away between render and submit, `/v1/create` fails cleanly (Waggle placement is all-or-nothing); there is no "Over Allocated" suffix on instance types anymore.
 
 **User identity:** All operations resolve the Slack user to their email via `client.users.info({ user: body.user.id })`. The email is stored as `owner` in VM tags and used to filter VMs on list.
 

--- a/listeners/actions/vm-region.js
+++ b/listeners/actions/vm-region.js
@@ -71,20 +71,11 @@ export default async function vmRegionCallback({ ack, body, client }) {
     );
   }
 
+  // The provisioner only lists instance types that can actually be placed right
+  // now (Proxmox regions: Waggle slots with room on some hypervisor), so the
+  // dropdown needs no extra capacity context.
   const regionObj = regions.find(r => r.region_name === selectedRegion);
   let servers = regionObj ? regionObj.available_instance_types : [];
-  const regionStats = regionObj != null && regionObj.cpu_pct != null
-    ? {
-        total_vcpus: regionObj.total_vcpus,
-        total_memory_gb: regionObj.total_memory_gb,
-        total_storage_gb: regionObj.total_storage_gb,
-        free_vcpus: regionObj.free_vcpus,
-        free_memory_gb: regionObj.free_memory_gb,
-        free_storage_gb: regionObj.free_storage_gb,
-        cpu_pct: regionObj.cpu_pct,
-        ram_pct: regionObj.ram_pct,
-      }
-    : null;
 
   // When creating multiple VMs, filter instance types by RAM
   if (vmCount > 1) {
@@ -113,7 +104,7 @@ export default async function vmRegionCallback({ ack, body, client }) {
   await client.views.update({
     view_id: body.view.id,
     view: vmModal({
-      regions, images, servers, metaData, vmCount, regionStats, selectedRegion,
+      regions, images, servers, metaData, vmCount, selectedRegion,
       profiles, selectedProfile, selectedImage, descriptions, cloneRepos, singleClick
     })
   });

--- a/listeners/views/vm-create-modal.js
+++ b/listeners/views/vm-create-modal.js
@@ -23,7 +23,7 @@ export default async function vmCreateModalCallback({ ack, view, body, client })
   // first", "No images available") and a missing selection from reaching the provisioner.
   if (!selectedRegion || selectedRegion === 'placeholder') errors.region = 'Please select a region.';
   if (!selectedImage || selectedImage === 'placeholder') errors.image = 'Please select an image.';
-  if (!selectedServer || selectedServer === 'placeholder') errors.server = 'Please pick a region first, then a server type.';
+  if (!selectedServer || selectedServer === 'placeholder') errors.server = 'Please pick a server type (if none are listed, the region is at capacity — try another region).';
 
   // Extract per-VM description + repo. Repo is validated and normalised to a canonical
   // https://github.com/owner/repo.git URL; blank is allowed (optional).

--- a/user-interface/modals/vm-create.js
+++ b/user-interface/modals/vm-create.js
@@ -3,7 +3,7 @@ import { Modal, Blocks, Elements, Bits } from 'slack-block-builder';
 // Env vars are NOT entered on this modal — they come solely from a selected profile
 // (managed via `/vm profile`; the recommended-keys guidance now lives in the profile-create
 // modal). This modal only picks a profile; the merge happens in listeners/views/vm-create-modal.js.
-export default function vmCreateModal({ regions = [], images = [], servers = [], metaData, vmCount = 1, regionStats = null, selectedRegion = null, profiles = [], selectedProfile = null, selectedImage = null, selectedServer = null, descriptions = [], cloneRepos = [], singleClick = false } = {}) {
+export default function vmCreateModal({ regions = [], images = [], servers = [], metaData, vmCount = 1, selectedRegion = null, profiles = [], selectedProfile = null, selectedImage = null, selectedServer = null, descriptions = [], cloneRepos = [], singleClick = false } = {}) {
   const title = vmCount > 1 ? `Create ${vmCount} VMs` : 'Create VM';
 
   // Per-VM fields: each VM gets its own description and repo to clone (different VMs are
@@ -70,14 +70,6 @@ export default function vmCreateModal({ regions = [], images = [], servers = [],
           )
       ),
 
-      ...(regionStats != null
-        ? [Blocks.Context().elements(
-            `*Total:*       ${regionStats.total_vcpus} vCPU  •  ${regionStats.total_memory_gb}GB RAM  •  ${regionStats.total_storage_gb}GB Disk\n` +
-            `*Unallocated:* ${regionStats.free_vcpus} vCPU  •  ${regionStats.free_memory_gb}GB RAM  •  ${regionStats.free_storage_gb}GB Disk\n` +
-            `${regionStats.cpu_pct >= 91 ? '🔴' : regionStats.cpu_pct >= 50 ? '🟡' : '🟢'} *Current load:* ${regionStats.cpu_pct}% CPU  •  ${regionStats.ram_pct}% RAM`
-          )]
-        : []),
-
       Blocks.Input({ label: 'Image', blockId: 'image' }).element(
         Elements.StaticSelect({ actionId: 'image' })
           .placeholder('Select an image')
@@ -100,12 +92,37 @@ export default function vmCreateModal({ regions = [], images = [], servers = [],
           .placeholder('Select a server type')
           .options(
             servers.length > 0
-              ? servers.map(server =>
-                  Bits.Option({ text: server.instance_type, value: server.instance_type })
-                )
-              : [Bits.Option({ text: 'Select a region first', value: 'placeholder' })]
+              // Spell the specs out from the payload — slot names are free-form
+              // in Waggle, so the name alone can't be relied on to carry them.
+              // The option VALUE stays the bare instance_type: it round-trips
+              // to the provisioner as the slot identifier.
+              ? servers.map(server => {
+                  const specs = [server.vcpus, server.memory_mb, server.storage_mb].every(Number.isFinite)
+                    ? ` (${server.vcpus} vCPU • ${Math.round(server.memory_mb / 1024)} GB RAM • ${Math.round(server.storage_mb / 1024)} GB disk)`
+                    : '';
+                  // Slack caps option text at 75 chars; prefer dropping the
+                  // specs over a hard API error on a long slot name.
+                  const label = `${server.instance_type}${specs}`;
+                  return Bits.Option({
+                    text: label.length <= 75 ? label : server.instance_type.slice(0, 75),
+                    value: server.instance_type
+                  });
+                })
+              // Keep value 'placeholder' — the submit handler rejects it with an inline error
+              : [Bits.Option({
+                  text: selectedRegion ? 'No server types available' : 'Select a region first',
+                  value: 'placeholder'
+                })]
           )
       ),
+
+      // The provisioner only lists server types that can be placed right now, so an
+      // empty list for a selected region means the region is at capacity.
+      ...(selectedRegion && servers.length === 0
+        ? [Blocks.Context().elements(
+            `:warning: *${selectedRegion}* is at capacity — no server types can be placed right now. Try another region or check back later.`
+          )]
+        : []),
 
       ...perVmBlocks,
 

--- a/util/libvirt/libvirt-server.js
+++ b/util/libvirt/libvirt-server.js
@@ -9,6 +9,18 @@ import { randomBytes } from 'crypto';
 
 const log = logger();
 
+// The provisioner's 4xx responses carry an actionable `detail` string (e.g.
+// region at capacity, VM not found). Surface it so users can self-serve
+// instead of guessing. 5xx bodies always carry a generic boilerplate detail
+// and FastAPI validation errors are arrays — both return an empty string.
+const provisionerDetail = (error) => {
+    const status = error?.response?.status;
+    const detail = error?.response?.data?.detail;
+    return typeof detail === 'string' && detail && status >= 400 && status < 500
+        ? `\nReason: ${detail}`
+        : '';
+};
+
 export default {
     createServer: async({ client, body, imageName, region, instanceType, description, channel_id, singleClickExperience, userEnv = {}, cloneRepo = null, profileName = null, batch = false }) => {
         //auto generate the name
@@ -96,7 +108,7 @@ export default {
                 await client.chat.postEphemeral({
                 channel: channel_id,
                 user: body.user.id,
-                text: `Failed to create server: ${serverName}\nDescription: ${descriptionText}`
+                text: `Failed to create server: ${serverName}\nDescription: ${descriptionText}${provisionerDetail(error)}`
                 });
             }
 
@@ -158,7 +170,7 @@ export default {
             app.client.chat.postEphemeral({
               channel: channel_id,
               user: user_id,
-              text: `Failed to delete Server: ${serverName}.`
+              text: `Failed to delete Server: ${serverName}.${provisionerDetail(error)}`
             });
         } 
     },
@@ -237,7 +249,7 @@ export default {
             app.client.chat.postEphemeral({
               channel: channel_id,
               user: user_id,
-              text: `Failed to start Server: ${serverName}.`
+              text: `Failed to start Server: ${serverName}.${provisionerDetail(error)}`
             });
         } 
     },
@@ -267,7 +279,7 @@ export default {
             app.client.chat.postEphemeral({
               channel: channel_id,
               user: user_id,
-              text: `Failed to stop Server: ${serverName}.`
+              text: `Failed to stop Server: ${serverName}.${provisionerDetail(error)}`
             });
         } 
     },
@@ -300,7 +312,7 @@ export default {
             client.chat.postEphemeral({
               channel: channel_id,
               user: user_id,
-              text: `Failed to edit Server: ${serverName}.`
+              text: `Failed to edit Server: ${serverName}.${provisionerDetail(error)}`
             });
         } 
     }


### PR DESCRIPTION
## Summary

UI adaptation for the provisioner's waggle-backed proxmox backend (pairs with GlueOps/provisioner#225). The bot stays provider-agnostic — these are presentation changes only:

- **Capacity stats block removed** (and all `regionStats` plumbing): proxmox regions now return only the Waggle slots that can actually be placed, so the instance-type dropdown *is* the availability signal — no client-side capacity math
- **At-capacity messaging**: a selected region with zero placeable server types shows a ⚠️ "region is at capacity — try another region or check back later" context note, a distinct dropdown placeholder, and a matching inline submit error (submit stays blocked via the existing `placeholder` guard)
- **Slot labels show specs** from the payload — `2vcpu-8gb-32ssd (2 vCPU • 8 GB RAM • 32 GB disk)` — with a 75-char Slack-limit fallback; the option **value** remains the bare slot name and round-trips to the provisioner verbatim (Waggle slot names are free-form, so the name alone can't be trusted to carry specs)
- **Actionable failure reasons**: provisioner 4xx `detail` strings (409 region-at-capacity, 404 VM-not-found, 422 unknown slot) are appended to failure messages as `Reason: …`; 5xx boilerplate and validation arrays are never surfaced
- Docs (CLAUDE.md, .ai/AGENTS.md) refreshed for the datacenter-level region model

## Compatibility

Region names are now datacenter-level (`proxmox-cluster-1`, not `…-pve-node-01`) but the bot always round-tripped names verbatim, so no logic changed. Libvirt regions render exactly as before (they've always had null capacity fields). The `vmCount > 1` RAM filter keeps working off `memory_mb`.

## Testing

`node --check` on all changed files; wire contract verified field-by-field against the provisioner's actual `/v1/regions` and `/v1/list` outputs, including exhaustive verification that every name the bot can generate passes the provisioner's new `vm_name` validation. No test infra exists in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)