### PR TITLE
feat: regional tunnel endpoints for CDE tunnels and access URLs

### DIFF
--- a/example.env
+++ b/example.env
@@ -14,7 +14,9 @@ APP_ENVIRONMENT=<nonprod | prod>
 # Set this (e.g. v0.155.0) when enabling per-region tunnel_endpoint values in
 # the provisioner's BAREMETAL_SERVER_CONFIGS; VMs created from older images
 # still fall back to the central tunnel so their access URLs stay correct.
-REGIONAL_TUNNEL_MIN_IMAGE_TAG=<codespaces release tag, e.g. v0.155.0>
+# Prerelease tags (vX.Y.Z-RC1) are supported on both sides: a stable release
+# outranks its own RCs, so min=v0.155.0-RC1 admits the RCs and the stable cut.
+REGIONAL_TUNNEL_MIN_IMAGE_TAG=<codespaces release tag, e.g. v0.155.0 or v0.155.0-RC1>
 
 # VM profiles store (required). The app fails to start if any of these are missing.
 # Must be a full URL including the scheme (https://). A bare host is rejected at startup.

--- a/example.env
+++ b/example.env
@@ -8,6 +8,14 @@ PROVISIONER_URL=https://example.com
 GUACAMOLE_CONNECTION_URL=<URL for guacamole connections>
 APP_ENVIRONMENT=<nonprod | prod>
 
+# Optional. Oldest GlueOps/codespaces image release whose baked dev() reads
+# /etc/glueops/tunnel_endpoint. Unset = regional tunnel endpoints disabled:
+# every CDE VM uses the legacy central tunnel regardless of region config.
+# Set this (e.g. v0.155.0) when enabling per-region tunnel_endpoint values in
+# the provisioner's BAREMETAL_SERVER_CONFIGS; VMs created from older images
+# still fall back to the central tunnel so their access URLs stay correct.
+REGIONAL_TUNNEL_MIN_IMAGE_TAG=<codespaces release tag, e.g. v0.155.0>
+
 # VM profiles store (required). The app fails to start if any of these are missing.
 # Must be a full URL including the scheme (https://). A bare host is rejected at startup.
 PROFILES_S3_ENDPOINT=https://s3.us-east-1.amazonaws.com

--- a/listeners/commands/vm.js
+++ b/listeners/commands/vm.js
@@ -1,4 +1,4 @@
-import libvirt from '../../util/libvirt/libvirt-server.js';
+import libvirt, { DEFAULT_TUNNEL_ENDPOINT } from '../../util/libvirt/libvirt-server.js';
 import vmCreateModal from '../../user-interface/modals/vm-create.js';
 import vmProfileModal from '../../user-interface/modals/vm-profile.js';
 import buttonBuilder from '../../util/button-builder.js';
@@ -260,7 +260,11 @@ export default {
           // Build header text with optional CDE URL
           let headerText = `Server: ${server.serverName}\nRegion: ${server.region}\nDescription: ${description}\nStatus: ${server.status}\nCreated: ${createdDate}\nRepo: ${cloneRepo || 'None'}`;
           if (cdeToken) {
-              const cdeUrl = `https://cde-${server.serverName}.tunnels.glueopshosted.com?folder=/workspaces/glueops&tkn=${cdeToken}`;
+              // The tunnel_endpoint tag records which sish host this VM's
+              // tunnel actually connects to; VMs created before regional
+              // tunnels have no tag and live on the legacy central endpoint.
+              const tunnelHost = server.tags.tunnel_endpoint || DEFAULT_TUNNEL_ENDPOINT;
+              const cdeUrl = `https://cde-${server.serverName}.${tunnelHost}?folder=/workspaces/glueops&tkn=${cdeToken}`;
               headerText += `\nAccess: <${cdeUrl}|Cloud Development Environment>`;
           }
 

--- a/listeners/commands/vm.js
+++ b/listeners/commands/vm.js
@@ -1,4 +1,4 @@
-import libvirt, { DEFAULT_TUNNEL_ENDPOINT } from '../../util/libvirt/libvirt-server.js';
+import libvirt, { DEFAULT_TUNNEL_ENDPOINT, cdeAccessUrl } from '../../util/libvirt/libvirt-server.js';
 import vmCreateModal from '../../user-interface/modals/vm-create.js';
 import vmProfileModal from '../../user-interface/modals/vm-profile.js';
 import buttonBuilder from '../../util/button-builder.js';
@@ -264,7 +264,7 @@ export default {
               // tunnel actually connects to; VMs created before regional
               // tunnels have no tag and live on the legacy central endpoint.
               const tunnelHost = server.tags.tunnel_endpoint || DEFAULT_TUNNEL_ENDPOINT;
-              const cdeUrl = `https://cde-${server.serverName}.${tunnelHost}?folder=/workspaces/glueops&tkn=${cdeToken}`;
+              const cdeUrl = cdeAccessUrl(server.serverName, tunnelHost, cdeToken);
               headerText += `\nAccess: <${cdeUrl}|Cloud Development Environment>`;
           }
 

--- a/util/get-user-data.js
+++ b/util/get-user-data.js
@@ -3,6 +3,13 @@
     that is used in the cloud init script for the VMs.
 */
 
+// Bare-hostname shape for a sish tunnel endpoint (no scheme, port, path, or
+// userinfo). Shared with libvirt-server.js, which validates at resolution
+// time: every consumer of the value (permanent VM tag, access URLs, the
+// cloud-init file write below) must accept or reject it identically, or a VM
+// ends up tunneled to one host while its advertised URLs point at another.
+export const TUNNEL_ENDPOINT_PATTERN = /^[a-z0-9][a-z0-9.-]*$/i;
+
 export default function configUserData(serverName, cdeToken = null, cdeEnv = {}, userEnv = {}) {
     let userData = `
         #cloud-config
@@ -18,7 +25,22 @@ export default function configUserData(serverName, cdeToken = null, cdeEnv = {},
     if (cdeToken) {
         userData += `
             - ['mkdir', '-p', '/etc/glueops']
-            - ['bash', '-c', 'echo "${cdeToken}" > /etc/glueops/cde_token && chmod 644 /etc/glueops/cde_token']
+            - ['bash', '-c', 'echo "${cdeToken}" > /etc/glueops/cde_token && chmod 644 /etc/glueops/cde_token']`;
+
+        // Regional sish endpoint, world-readable like cde_token because the
+        // host-side dev() (developer-setup.sh) reads it as the vscode user —
+        // codespace.env is root-only so it can't serve this. Absent file ->
+        // dev() falls back to the legacy central tunnel, which is also why the
+        // hostname is re-validated here (defence-in-depth; the resolver
+        // already enforced it): a value that can't round-trip safely through
+        // this runcmd is dropped rather than escaped.
+        const tunnelEndpoint = cdeEnv?.TUNNEL_ENDPOINT;
+        if (tunnelEndpoint && TUNNEL_ENDPOINT_PATTERN.test(tunnelEndpoint)) {
+            userData += `
+            - ['bash', '-c', 'echo "${tunnelEndpoint}" > /etc/glueops/tunnel_endpoint && chmod 644 /etc/glueops/tunnel_endpoint']`;
+        }
+
+        userData += `
             - ['su', '-', 'vscode', '-c', 'source ~/.glueopsrc; dev || true']`;
     }
 

--- a/util/libvirt/libvirt-server.js
+++ b/util/libvirt/libvirt-server.js
@@ -50,7 +50,11 @@ const getTunnelEndpoint = async (region) => {
             headers: { 'Authorization': `${process.env.PROVISIONER_API_TOKEN}` },
             timeout: 1000 * 30
         });
-        const endpoint = res.data?.find(r => r.region_name === region)?.tunnel_endpoint?.trim();
+        // Normalize case and any trailing dot: DNS treats them as equivalent,
+        // but the legacy-vs-regional split in cdeAccessUrl and on the VM is an
+        // exact string comparison against DEFAULT_TUNNEL_ENDPOINT.
+        const endpoint = res.data?.find(r => r.region_name === region)
+            ?.tunnel_endpoint?.trim().toLowerCase().replace(/\.$/, '');
         if (!endpoint) return DEFAULT_TUNNEL_ENDPOINT;
         if (!TUNNEL_ENDPOINT_PATTERN.test(endpoint)) {
             log.error(`Region ${region} has invalid tunnel_endpoint "${endpoint}", using default`);
@@ -63,27 +67,51 @@ const getTunnelEndpoint = async (region) => {
     }
 };
 
+// Parse a codespaces release tag into its numeric core and optional
+// prerelease suffix. Accepts the repo's real tag shapes: vX.Y.Z and
+// prereleases like vX.Y.Z-RC1 (nonprod's image picker serves those). The
+// strict shape check matters: Number('') is 0, not NaN, so a typo like "v"
+// would otherwise parse as [0] and open the gate for every old image.
+const parseImageTag = (tag) => {
+    const m = /^v?(\d+(?:\.\d+)*)(?:-([0-9a-z.-]+))?$/i.exec(String(tag).trim());
+    if (!m) return null;
+    return { core: m[1].split('.').map(Number), pre: m[2]?.toLowerCase() ?? null };
+};
+
+const compareImageTags = (a, b) => {
+    for (let i = 0; i < Math.max(a.core.length, b.core.length); i++) {
+        const d = (a.core[i] || 0) - (b.core[i] || 0);
+        if (d) return d;
+    }
+    // Equal numeric cores: a stable release outranks its own prereleases (an
+    // RC may predate fixes in the stable cut); prereleases compare naturally
+    // so RC2 < RC10.
+    if (!a.pre && !b.pre) return 0;
+    if (!a.pre) return 1;
+    if (!b.pre) return -1;
+    return a.pre.localeCompare(b.pre, undefined, { numeric: true });
+};
+
 // Images older than REGIONAL_TUNNEL_MIN_IMAGE_TAG bake a dev() that ignores
 // /etc/glueops/tunnel_endpoint and always tunnels to the legacy central
 // endpoint, so giving such a VM a regional endpoint would advertise dead
-// access URLs. Unset (or an unparseable tag on either side) means regional
-// tunnels stay off entirely — fail-safe until the operator declares which
-// codespaces release can honor them.
+// access URLs. Unset means regional tunnels stay off entirely; unparseable
+// tags fail safe to legacy but are logged loudly, because a set-but-broken
+// gate must not be indistinguishable from the feature being off.
 const imageSupportsRegionalTunnel = (imageName) => {
     const min = process.env.REGIONAL_TUNNEL_MIN_IMAGE_TAG;
     if (!min) return false;
-    // Shape-check before splitting: Number('') is 0, not NaN, so without this
-    // a typo like "v" or a bare space would parse as [0] and open the gate
-    // for every old image.
-    const parse = tag => /^v?\d+(\.\d+)*$/.test(String(tag).trim())
-        ? String(tag).trim().replace(/^v/, '').split('.').map(Number)
-        : null;
-    const image = parse(imageName), floor = parse(min);
-    if (!image || !floor) return false;
-    for (let i = 0; i < Math.max(image.length, floor.length); i++) {
-        if ((image[i] || 0) !== (floor[i] || 0)) return (image[i] || 0) > (floor[i] || 0);
+    const floor = parseImageTag(min);
+    if (!floor) {
+        log.error(`REGIONAL_TUNNEL_MIN_IMAGE_TAG "${min}" is not a parseable release tag; regional tunnels stay OFF`);
+        return false;
     }
-    return true;
+    const image = parseImageTag(imageName);
+    if (!image) {
+        log.error(`Image tag "${imageName}" is not a parseable release tag; VM falls back to the legacy tunnel endpoint`);
+        return false;
+    }
+    return compareImageTags(image, floor) >= 0;
 };
 
 export default {

--- a/util/libvirt/libvirt-server.js
+++ b/util/libvirt/libvirt-server.js
@@ -26,6 +26,18 @@ const provisionerDetail = (error) => {
 // declare its own tunnel_endpoint (or the lookup fails outright).
 export const DEFAULT_TUNNEL_ENDPOINT = 'tunnels.glueopshosted.com';
 
+// Access URL for a CDE VM. The legacy central sish appends the SSH username
+// to a "cde" bind (cde-<name>.tunnels...); regional instances let the VM
+// bind its bare hostname (<name>.<region>.tunnels.cde...). The VM-side rule
+// in the codespaces image's developer-setup.sh derives the bind from the
+// same endpoint value, so URL and tunnel can never disagree.
+export const cdeAccessUrl = (serverName, tunnelEndpoint, cdeToken) => {
+    const host = tunnelEndpoint === DEFAULT_TUNNEL_ENDPOINT
+        ? `cde-${serverName}.${tunnelEndpoint}`
+        : `${serverName}.${tunnelEndpoint}`;
+    return `https://${host}?folder=/workspaces/glueops&tkn=${cdeToken}`;
+};
+
 // Resolve the sish endpoint for a region from the provisioner's region
 // config. Never throws: creation must not fail (or silently go central-only
 // with a regional URL) because of a transient /v1/regions error. A value that
@@ -185,7 +197,7 @@ export default {
         //return info for connection
         let accessUrl, accessLabel;
         if (cdeToken) {
-            accessUrl = `https://cde-${serverName}.${tunnelEndpoint}?folder=/workspaces/glueops&tkn=${cdeToken}`;
+            accessUrl = cdeAccessUrl(serverName, tunnelEndpoint, cdeToken);
             accessLabel = 'Cloud Development Environment';
         } else {
             accessUrl = process.env.GUACAMOLE_CONNECTION_URL;

--- a/util/libvirt/libvirt-server.js
+++ b/util/libvirt/libvirt-server.js
@@ -1,7 +1,7 @@
 import logger from '../logger.js';
 import 'dotenv/config';
 import axios from 'axios';
-import configUserData from "../get-user-data.js";
+import configUserData, { TUNNEL_ENDPOINT_PATTERN } from "../get-user-data.js";
 import axiosError from '../axios-error-handler.js';
 import { uniqueNamesGenerator, colors, animals } from 'unique-names-generator';
 import { generateCdeToken } from '../token-generator.js';
@@ -21,6 +21,59 @@ const provisionerDetail = (error) => {
         : '';
 };
 
+// Legacy central sish endpoint. Every VM created before regional tunnels
+// existed connects here, so it is the fallback whenever a region doesn't
+// declare its own tunnel_endpoint (or the lookup fails outright).
+export const DEFAULT_TUNNEL_ENDPOINT = 'tunnels.glueopshosted.com';
+
+// Resolve the sish endpoint for a region from the provisioner's region
+// config. Never throws: creation must not fail (or silently go central-only
+// with a regional URL) because of a transient /v1/regions error. A value that
+// fails the hostname pattern is rejected here, before it fans out to the
+// permanent tag, the access URLs, and cloud-init — those consumers must all
+// agree on one endpoint, and cloud-init would silently drop a non-hostname.
+const getTunnelEndpoint = async (region) => {
+    try {
+        const res = await axios.get(`${process.env.PROVISIONER_URL}/v1/regions`, {
+            headers: { 'Authorization': `${process.env.PROVISIONER_API_TOKEN}` },
+            timeout: 1000 * 30
+        });
+        const endpoint = res.data?.find(r => r.region_name === region)?.tunnel_endpoint?.trim();
+        if (!endpoint) return DEFAULT_TUNNEL_ENDPOINT;
+        if (!TUNNEL_ENDPOINT_PATTERN.test(endpoint)) {
+            log.error(`Region ${region} has invalid tunnel_endpoint "${endpoint}", using default`);
+            return DEFAULT_TUNNEL_ENDPOINT;
+        }
+        return endpoint;
+    } catch (error) {
+        log.error('Failed to resolve tunnel endpoint, using default', axiosError(error));
+        return DEFAULT_TUNNEL_ENDPOINT;
+    }
+};
+
+// Images older than REGIONAL_TUNNEL_MIN_IMAGE_TAG bake a dev() that ignores
+// /etc/glueops/tunnel_endpoint and always tunnels to the legacy central
+// endpoint, so giving such a VM a regional endpoint would advertise dead
+// access URLs. Unset (or an unparseable tag on either side) means regional
+// tunnels stay off entirely — fail-safe until the operator declares which
+// codespaces release can honor them.
+const imageSupportsRegionalTunnel = (imageName) => {
+    const min = process.env.REGIONAL_TUNNEL_MIN_IMAGE_TAG;
+    if (!min) return false;
+    // Shape-check before splitting: Number('') is 0, not NaN, so without this
+    // a typo like "v" or a bare space would parse as [0] and open the gate
+    // for every old image.
+    const parse = tag => /^v?\d+(\.\d+)*$/.test(String(tag).trim())
+        ? String(tag).trim().replace(/^v/, '').split('.').map(Number)
+        : null;
+    const image = parse(imageName), floor = parse(min);
+    if (!image || !floor) return false;
+    for (let i = 0; i < Math.max(image.length, floor.length); i++) {
+        if ((image[i] || 0) !== (floor[i] || 0)) return (image[i] || 0) > (floor[i] || 0);
+    }
+    return true;
+};
+
 export default {
     createServer: async({ client, body, imageName, region, instanceType, description, channel_id, singleClickExperience, userEnv = {}, cloneRepo = null, profileName = null, batch = false }) => {
         //auto generate the name
@@ -31,6 +84,18 @@ export default {
 
         // Generate CDE token if Single-Click Experience is enabled
         const cdeToken = singleClickExperience ? generateCdeToken() : null;
+
+        // The sish tunnel only runs on CDE-enabled VMs, so only resolve the
+        // endpoint for those, and only when the chosen image can actually read
+        // it — otherwise the VM gets the legacy endpoint so its tag and URLs
+        // match where the tunnel really connects. Recorded in tags below as
+        // the permanent truth (the region config may change later).
+        let tunnelEndpoint = null;
+        if (cdeToken) {
+            tunnelEndpoint = imageSupportsRegionalTunnel(imageName)
+                ? await getTunnelEndpoint(region)
+                : DEFAULT_TUNNEL_ENDPOINT;
+        }
 
         // Call the users.info method using the WebClient
         let info;
@@ -70,6 +135,7 @@ export default {
             "description": description || '',
             "created_at": new Date().toISOString(),
             ...(cdeToken && { "cde_token": cdeToken }),
+            ...(tunnelEndpoint && { "tunnel_endpoint": tunnelEndpoint }),
             ...(cloneRepo && { "clone_repo": cloneRepo })
         };
 
@@ -86,6 +152,7 @@ export default {
                         IMAGE: imageName,
                         OWNER: userEmail,
                         CREATED_AT: tags.created_at,
+                        ...(tunnelEndpoint && { TUNNEL_ENDPOINT: tunnelEndpoint }),
                         // Platform-namespaced clone hint; consumed by the codespaces
                         // image's developer-setup.sh at boot (per-create, not persisted).
                         // The default branch is always used.
@@ -118,7 +185,7 @@ export default {
         //return info for connection
         let accessUrl, accessLabel;
         if (cdeToken) {
-            accessUrl = `https://cde-${serverName}.tunnels.glueopshosted.com?folder=/workspaces/glueops&tkn=${cdeToken}`;
+            accessUrl = `https://cde-${serverName}.${tunnelEndpoint}?folder=/workspaces/glueops&tkn=${cdeToken}`;
             accessLabel = 'Cloud Development Environment';
         } else {
             accessUrl = process.env.GUACAMOLE_CONNECTION_URL;


### PR DESCRIPTION
## What

Regional tunnel endpoints for CDE VMs: instead of every codespace tunneling to the single central `tunnels.glueopshosted.com`, each region can declare its own sish endpoint (e.g. `nyc1.tunnels.cde.glueopshosted.com`) and new VMs connect to the closest one. Access URLs become `https://<vm>.<region>.tunnels.cde.glueopshosted.com` (regional endpoints drop the legacy `cde-` prefix — the shared `cdeAccessUrl()` builder keeps `cde-<vm>.tunnels.glueopshosted.com` for the legacy endpoint, matching the bind rule in the codespaces image).

- **`util/libvirt/libvirt-server.js`** — at create time (single-click/CDE VMs only), resolves the region's `tunnel_endpoint` from the provisioner's `/v1/regions`. The resolved endpoint is:
  - recorded in the VM tags as `tunnel_endpoint` — the permanent record of where this VM's tunnel actually connects;
  - passed to cloud-init (`TUNNEL_ENDPOINT`);
  - used to build the access URL.

  Resolution is fail-safe: any lookup error, a region without the field, a value failing hostname validation, or an image older than `REGIONAL_TUNNEL_MIN_IMAGE_TAG` all resolve to the legacy central endpoint, so the tag, the URLs, and the VM's real tunnel can never disagree.
- **`util/get-user-data.js`** — cloud-init writes `/etc/glueops/tunnel_endpoint` (world-readable, mirroring `cde_token`) before `dev` runs; the shared `TUNNEL_ENDPOINT_PATTERN` hostname check is re-applied as defence-in-depth. The endpoint also lands in `codespace.env` as `GLUEOPS_CDE_TUNNEL_ENDPOINT`.
- **`listeners/commands/vm.js`** — `/vm list` builds each CDE URL from `tags.tunnel_endpoint`, falling back to the legacy endpoint for VMs created before this change.
- **`example.env`** — documents the new optional `REGIONAL_TUNNEL_MIN_IMAGE_TAG`.

Companion PRs: GlueOps/provisioner (region config field + fail-fast validation) and GlueOps/codespaces (`dev()` reads the endpoint file).

## New environment variable

| Variable | Required | Purpose |
|---|---|---|
| `REGIONAL_TUNNEL_MIN_IMAGE_TAG` | No | Oldest codespaces image release whose baked `dev()` reads `/etc/glueops/tunnel_endpoint`. **Unset = regional tunnels off** (all VMs legacy central). Older images bake a `dev()` that ignores the file, so without this gate a regional region + old image would produce a VM tunneled centrally behind dead regional URLs. |

## Backward compatibility

| VM image | Slackbot | Region `tunnel_endpoint` | `REGIONAL_TUNNEL_MIN_IMAGE_TAG` | Result |
|---|---|---|---|---|
| any existing VM | any | any | any | untouched; `/vm list` shows legacy URL (no tag) |
| old | new | set | set | gated → legacy endpoint everywhere, consistent |
| new | new | unset/invalid | set | legacy endpoint everywhere, consistent |
| new | new | set | unset | regional tunnels off → legacy everywhere |
| new (≥ min tag) | new | set | set | regional tunnel + regional URL ✅ |

There is no combination in which the advertised URL and the VM's actual tunnel disagree.

## How to upgrade (full rollout runbook)

Deploy order — each step is inert until the next:

1. **Provisioner**: deploy the release with the `tunnel_endpoint` field. Do not set the field on any region yet.
2. **Slackbot**: deploy this PR. Behavior is unchanged until `REGIONAL_TUNNEL_MIN_IMAGE_TAG` is set.
3. **Codespaces image**: merge the codespaces PR, note the release tag (e.g. `v0.155.0`), and set `REGIONAL_TUNNEL_MIN_IMAGE_TAG` to it in the slackbot environment. Still inert — no region declares an endpoint yet.
4. **Per region, one at a time**:
   1. Deploy the regional sish box via GlueOps/cde-sish-tunnels#33 (≥ 0.4, regional-only): `.env` sets `DOMAIN=<region>.tunnels.cde.glueopshosted.com` plus the `cde_acme_*` AWS creds — no naming flag needed, the stack binds bare hostnames by construction; the certbot sidecar issues the box's wildcard cert automatically. (Never deploy repo tip onto the legacy central box — it stays pinned pre-0.4.)
   2. DNS + CloudFront are Terraform-managed — do **not** hand-create records: add the region + box IP to `cde_tunnel_regions` in glueops-opentofu-workspaces/aws-cloud-development-environment-assets-production#74 and follow that PR's apply steps (creates the bare `A` for SSH, the `origin.<region>` A, the ACM cert, the CloudFront distribution, and the wildcard CNAME → CloudFront).
   3. Smoke-test the naming mode by hand: `ssh -p 2222 -R smoketest:80:localhost:8080 <region>.tunnels.cde.glueopshosted.com`, then curl `https://smoketest.<region>.tunnels.cde.glueopshosted.com` (bare bind, no `<user>-` prefix — if the URL sish prints has one, `SISH_SUBDOMAIN_FLAGS` is missing).
   4. Set `"tunnel_endpoint": "<region>.tunnels.cde.glueopshosted.com"` on that region in `BAREMETAL_SERVER_CONFIGS`; restart the provisioner (a malformed value fails startup by design).
   5. Create a test VM through Slack with a current image and click the access link.
5. **Decommission (eventually)**: the central `tunnels.glueopshosted.com` keeps serving legacy VMs and gated fallbacks. Retire it only when sish's admin console shows no connected clients and `/v1/list` shows no CDE VMs without a `tunnel_endpoint` tag.

Rollback at any point = unset `tunnel_endpoint` on the region (or unset `REGIONAL_TUNNEL_MIN_IMAGE_TAG` to switch the feature off globally); existing VMs are unaffected either way because their tag records where they actually connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
